### PR TITLE
Add gradient styling to ResumeUpload component

### DIFF
--- a/src/features/ResumeUpload.jsx
+++ b/src/features/ResumeUpload.jsx
@@ -33,15 +33,20 @@ export default function ResumeUpload() {
   };
 
   return (
-    <div className="p-6 max-w-md mx-auto bg-white shadow rounded">
+    <div className="p-6 max-w-md mx-auto bg-gradient-to-r from-blue-50 to-purple-50 text-gray-700 rounded-xl shadow-lg">
       <h2 className="text-xl font-semibold mb-4">Step 1: Upload Resume</h2>
       <input type="file" onChange={handleFileChange} className="mb-4" />
-      <button onClick={handleUpload} disabled={uploading} className="btn">
+      <button
+        type="button"
+        onClick={handleUpload}
+        disabled={uploading}
+        className="btn-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+      >
         {uploading ? "Uploading..." : "Upload"}
       </button>
 
       {url && (
-        <p className="mt-4 text-sm text-gray-600">
+        <p className="mt-4 text-sm">
           ✅ File uploaded: <a href={url} target="_blank" className="text-blue-600">View Resume</a>
         </p>
       )}


### PR DESCRIPTION
## Summary
- apply gradient background, neutral typography, and shadow to resume upload card
- switch upload button to `.btn-primary` with visible focus states

## Testing
- `npm run build`
- `npm run lint` *(fails: Missing script "lint")*
- `npm run test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf2a248e6c833086b4167d94cfb7fd