### PR TITLE
Add Saudi green primary button style

### DIFF
--- a/src/features/JobMatch.jsx
+++ b/src/features/JobMatch.jsx
@@ -17,7 +17,7 @@ export default function JobMatch() {
         />
         <button
           onClick={() => navigate("/results")}
-          className="btn-primary w-full"
+          className="btn btn-primary w-full"
         >
           Next
         </button>

--- a/src/features/ResumeUpload.jsx
+++ b/src/features/ResumeUpload.jsx
@@ -36,7 +36,7 @@ export default function ResumeUpload() {
     <div className="p-6 max-w-md mx-auto bg-white shadow rounded">
       <h2 className="text-xl font-semibold mb-4">Step 1: Upload Resume</h2>
       <input type="file" onChange={handleFileChange} className="mb-4" />
-      <button onClick={handleUpload} disabled={uploading} className="btn">
+      <button onClick={handleUpload} disabled={uploading} className="btn btn-primary">
         {uploading ? "Uploading..." : "Upload"}
       </button>
 

--- a/src/index.css
+++ b/src/index.css
@@ -6,14 +6,16 @@
   --color-secondary: #F5A623; /* gold */
 }
 
+@utility btn {
+  @apply px-4 py-2 rounded-lg font-medium shadow-sm transition text-white;
+}
+
 @layer components {
-  .btn {
-    @apply px-4 py-2 rounded-lg font-medium shadow-sm transition
-           text-white bg-[#006C35] hover:bg-[#00522A];
+  .btn-primary {
+    @apply btn bg-primary hover:bg-green-700;
   }
 
   .btn-secondary {
-    @apply px-4 py-2 rounded-lg font-medium shadow-sm transition
-           text-white bg-[#F5A623] hover:bg-[#D4881F];
+    @apply btn bg-secondary hover:bg-[#D4881F];
   }
 }


### PR DESCRIPTION
## Summary
- define a reusable `btn-primary` class and move base button styles into a custom utility
- use `btn btn-primary` for key actions like resume upload and job match

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf2a2256088330ac93d1d30a1b4259