### PR TITLE
Resolve merge artifacts and redirect Google sign-in to resume page

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,24 +1,11 @@
-<<<<<<< ours
 import js from '@eslint/js';
 import globals from 'globals';
-
-export default [
-  js.configs.recommended,
-  {
-    files: ['**/*.{js,jsx}'],
-    languageOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      parserOptions: { ecmaFeatures: { jsx: true } },
-=======
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
 
 export default [
   {
-    ignores: ['node_modules'],
+    ignores: ['dist', 'node_modules'],
   },
   js.configs.recommended,
   {
@@ -26,22 +13,10 @@ export default [
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: 'module',
->>>>>>> theirs
       globals: {
         ...globals.browser,
         ...globals.node,
       },
-<<<<<<< ours
-    },
-    rules: {
-      'no-unused-vars': 'off',
-    },
-  },
-  {
-    ignores: ['dist', 'node_modules'],
-  },
-];
-=======
       parserOptions: {
         ecmaFeatures: { jsx: true },
       },
@@ -55,5 +30,4 @@ export default [
       'react-refresh/only-export-components': 'warn',
     },
   },
-]
->>>>>>> theirs
+];

--- a/package.json
+++ b/package.json
@@ -6,19 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-<<<<<<< ours
-<<<<<<< HEAD
+    "preview": "vite preview",
     "lint": "eslint .",
-    "test": "vitest run --reporter=verbose"
-=======
-    "preview": "vite preview",
-    "lint": "eslint src/services/api.js src/components/MainContent.jsx src/components/Features/JobMatch.jsx src/services/api.test.js",
     "test": "vitest run"
->>>>>>> 7ba4af30aa9cc4773527324cfea98d50f9548f00
-=======
-    "preview": "vite preview",
-    "lint": "eslint src/features/JobMatch.jsx"
->>>>>>> theirs
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.57.2",
@@ -45,10 +35,6 @@
     "tailwindcss": "^4.1.13",
     "typescript": "^5.9.2",
     "vite": "^7.1.4",
-<<<<<<< HEAD
     "vitest": "^3.2.4"
-=======
-    "vitest": "^1.6.1"
->>>>>>> 7ba4af30aa9cc4773527324cfea98d50f9548f00
   }
 }

--- a/src/__tests__/useAuth.test.jsx
+++ b/src/__tests__/useAuth.test.jsx
@@ -1,0 +1,19 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { AuthProvider, useAuth } from '../hooks/useAuth';
+import { supabase } from '../services/supabase';
+
+describe('useAuth', () => {
+  it('redirects to /resume on Google sign in', async () => {
+    supabase.auth.signInWithOAuth = vi.fn().mockResolvedValue({});
+    const wrapper = ({ children }) => <AuthProvider>{children}</AuthProvider>;
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await act(async () => {
+      await result.current.signInWithGoogle();
+    });
+    expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: { redirectTo: `${window.location.origin}/resume` },
+    });
+  });
+});

--- a/src/features/ResumeUpload.jsx
+++ b/src/features/ResumeUpload.jsx
@@ -36,16 +36,12 @@ export default function ResumeUpload() {
     <div className="p-6 max-w-md mx-auto bg-gradient-to-r from-blue-50 to-purple-50 text-gray-700 rounded-xl shadow-lg">
       <h2 className="text-xl font-semibold mb-4">Step 1: Upload Resume</h2>
       <input type="file" onChange={handleFileChange} className="mb-4" />
-<<<<<<< HEAD
-      <button onClick={handleUpload} disabled={uploading} className="btn btn-primary">
-=======
       <button
         type="button"
         onClick={handleUpload}
         disabled={uploading}
         className="btn-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
       >
->>>>>>> 7ba4af30aa9cc4773527324cfea98d50f9548f00
         {uploading ? "Uploading..." : "Upload"}
       </button>
 

--- a/src/hooks/useAuth.jsx
+++ b/src/hooks/useAuth.jsx
@@ -26,6 +26,7 @@ export const AuthProvider = ({ children }) => {
   const signInWithGoogle = async () => {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
+      options: { redirectTo: `${window.location.origin}/resume` },
     });
     if (error) console.error("Google login error:", error.message);
   };


### PR DESCRIPTION
## Summary
- clean up merge markers in package.json and scripts
- restore ESLint config and ResumeUpload button classes
- redirect Google auth flow straight to /resume and cover with a unit test

## Testing
- `npm ci` *(fails: network/proxy issue, command hung)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b6ac113c8330b387b8902d3164b4