### PR TITLE
codex: apply neutral design tokens and focus states

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ Analyzes a resume against a job description and returns:
 
 ## 🖼️ Screenshots
 <!-- Add 2–3 images here: upload to /public and link them -->
+
+## 🎨 Design tokens
+- Neutral palette and soft shadows via Tailwind utilities
+- Reusable `btn`, `input-base`, and `card` classes with visible focus rings
+

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/__tests__/useAuth.test.jsx
+++ b/src/__tests__/useAuth.test.jsx
@@ -1,18 +1,35 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, act } from '@testing-library/react';
+
+const { mockSignIn, mockOnAuth, mockGetSession } = vi.hoisted(() => ({
+  mockSignIn: vi.fn().mockResolvedValue({}),
+  mockOnAuth: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+  mockGetSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+}));
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    auth: {
+      signInWithOAuth: mockSignIn,
+      onAuthStateChange: mockOnAuth,
+      getSession: mockGetSession,
+      signOut: vi.fn(),
+    },
+  }),
+}));
+
 import { AuthProvider, useAuth } from '../hooks/useAuth';
 import { supabase } from '../services/supabase';
 
 describe('useAuth', () => {
   it('redirects to /resume on Google sign in', async () => {
-    supabase.auth.signInWithOAuth = vi.fn().mockResolvedValue({});
     const wrapper = ({ children }) => <AuthProvider>{children}</AuthProvider>;
     const { result } = renderHook(() => useAuth(), { wrapper });
     await act(async () => {
       await result.current.signInWithGoogle();
     });
-    expect(supabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+    expect(mockSignIn).toHaveBeenCalledWith({
       provider: 'google',
       options: { redirectTo: `${window.location.origin}/resume` },
     });

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -1,11 +1,11 @@
 export default function Header() {
   return (
-    <header className="bg-green-700 text-white px-6 py-4 flex justify-between items-center shadow">
+    <header className="bg-primary text-white px-6 py-4 flex justify-between items-center shadow-soft">
       <h1 className="text-xl font-bold">AI Resume Optimizer</h1>
-      <nav className="space-x-4">
-        <a href="/" className="hover:underline">Home</a>
-        <a href="/resume" className="hover:underline">Upload</a>
-        <a href="/results" className="hover:underline">Results</a>
+      <nav className="flex gap-4">
+        <a href="/" className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white rounded">Home</a>
+        <a href="/resume" className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white rounded">Upload</a>
+        <a href="/results" className="hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-white rounded">Results</a>
       </nav>
     </header>
   );

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -10,10 +10,60 @@ import JobMatch from './Features/JobMatch.jsx';
 import Optimization from '../features/Optimization.jsx';
 
 // --- Reusable UI Components ---
-const ProgressBar = ({ progress }) => ( <div className="h-1 bg-gradient-to-r from-purple-600/20 to-pink-600/20 rounded-full overflow-hidden"> <div className="h-full bg-gradient-to-r from-purple-600 to-pink-600 rounded-full transition-all duration-500" style={{ width: `${progress}%` }} /> </div> );
-const LoadingOverlay = ({ message }) => ( <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center"> <div className="bg-white rounded-2xl p-8 shadow-2xl flex flex-col items-center space-y-4"> <Loader2 className="w-12 h-12 text-purple-600 animate-spin" /> <p className="text-gray-700 font-medium">{message}</p> </div> </div> );
-const Notification = ({ message, type, onClose }) => { React.useEffect(() => { const timer = setTimeout(onClose, 4000); return () => clearTimeout(timer); }, [onClose]); const colors = { success: 'bg-green-500', error: 'bg-red-500', info: 'bg-blue-500' }; const icon = { success: <Check />, error: <X />, info: <AlertCircle /> }; return ( <div className={`fixed top-20 right-4 ${colors[type]} text-white px-6 py-4 rounded-xl shadow-xl z-50 flex items-center space-x-3`}> {icon[type]} <span>{message}</span> </div> ); };
-const TabButton = ({ active, onClick, children, icon }) => ( <button onClick={onClick} className={`relative px-6 py-4 font-semibold transition-all duration-300 w-full ${active ? 'text-purple-700 bg-white/90 shadow-lg' : 'text-gray-600 hover:bg-white/50'}`}> <div className="flex items-center justify-center space-x-2">{icon}<span>{children}</span></div> {active && <div className="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-purple-600 to-pink-600" />} </button> );
+const ProgressBar = ({ progress }) => (
+  <div
+    className="h-1 bg-gradient-to-r from-purple-600/20 to-pink-600/20 rounded-full overflow-hidden"
+    role="progressbar"
+    aria-valuenow={progress}
+    aria-valuemin="0"
+    aria-valuemax="100"
+  >
+    <div
+      className="h-full bg-gradient-to-r from-purple-600 to-pink-600 rounded-full transition-all duration-500"
+      style={{ width: `${progress}%` }}
+    />
+  </div>
+);
+
+const LoadingOverlay = ({ message }) => (
+  <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center">
+    <div className="bg-white rounded-2xl p-8 shadow-2xl flex flex-col items-center space-y-4">
+      <Loader2 className="w-12 h-12 text-purple-600 animate-spin motion-reduce:animate-none" />
+      <p className="text-gray-700 font-medium">{message}</p>
+    </div>
+  </div>
+);
+
+const Notification = ({ message, type, onClose }) => {
+  React.useEffect(() => {
+    const timer = setTimeout(onClose, 4000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+  const colors = { success: 'bg-green-500', error: 'bg-red-500', info: 'bg-blue-500' };
+  const icon = { success: <Check />, error: <X />, info: <AlertCircle /> };
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`fixed top-20 right-4 ${colors[type]} text-white px-6 py-4 rounded-xl shadow-xl z-50 flex items-center space-x-3`}
+    >
+      {icon[type]} <span>{message}</span>
+    </div>
+  );
+};
+
+const TabButton = ({ active, onClick, children, icon }) => (
+  <button
+    onClick={onClick}
+    className={`relative px-6 py-4 font-semibold transition-all duration-300 w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${active ? 'text-purple-700 bg-white/90 shadow-lg' : 'text-gray-600 hover:bg-white/50'}`}
+  >
+    <div className="flex items-center justify-center space-x-2">
+      {icon}
+      <span>{children}</span>
+    </div>
+    {active && <div className="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-purple-600 to-pink-600" />}
+  </button>
+);
 
 const AuthScreen = ({ onLogin }) => (
     <div className="text-center p-8 md:p-12">

--- a/src/features/JobMatch.jsx
+++ b/src/features/JobMatch.jsx
@@ -1,5 +1,4 @@
 // src/components/Features/JobMatch.jsx
-/* eslint-disable no-unused-vars */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Gauge, Lightbulb } from "lucide-react";
@@ -10,20 +9,20 @@ export default function JobMatch() {
   const [result] = useState(null);
 
   return (
-    <div className="flex justify-center items-center h-screen">
-      <div className="w-full max-w-lg bg-white rounded-xl shadow-lg p-6">
+    <div className="flex justify-center items-center h-screen" dir="auto">
+      <div className="card w-full max-w-lg">
         <h2 className="text-2xl font-semibold mb-4 text-primary">
           Step 2: Paste Job Description
         </h2>
         <label
           htmlFor="job-description"
-          className="block mb-2 font-medium text-gray-700"
+          className="block mb-2 font-medium text-neutral-700"
         >
           Job Description
         </label>
         <textarea
           id="job-description"
-          className="mb-6 w-full border rounded p-2"
+          className="input-base mb-6"
           rows="6"
           placeholder="Paste the job description here..."
           value={jobDescription}
@@ -31,13 +30,13 @@ export default function JobMatch() {
         />
         <button
           onClick={() => navigate("/results")}
-          className="btn btn-primary w-full"
+          className="btn-primary w-full"
         >
           Next
         </button>
 
         {result && (
-          <div className="mt-6 border border-gray-200 rounded-lg p-4 bg-gray-50">
+          <div className="mt-6 border border-neutral-200 rounded-2xl p-4 bg-neutral-50">
             <div className="flex items-center mb-2">
               <Gauge className="w-5 h-5 text-primary mr-2" />
               <span className="font-semibold text-gray-700">
@@ -46,7 +45,7 @@ export default function JobMatch() {
             </div>
             <div className="flex items-start">
               <Lightbulb className="w-5 h-5 text-primary mr-2 mt-1" />
-              <ul className="list-disc pl-5 text-gray-700">
+              <ul className="list-disc pl-5 text-neutral-700">
                 {result.suggestions.map((s, idx) => (
                   <li key={idx}>{s}</li>
                 ))}

--- a/src/features/ResumeUpload.jsx
+++ b/src/features/ResumeUpload.jsx
@@ -33,21 +33,29 @@ export default function ResumeUpload() {
   };
 
   return (
-    <div className="p-6 max-w-md mx-auto bg-gradient-to-r from-blue-50 to-purple-50 text-gray-700 rounded-xl shadow-lg">
+    <div className="card max-w-md mx-auto text-neutral-700" dir="auto">
       <h2 className="text-xl font-semibold mb-4">Step 1: Upload Resume</h2>
-      <input type="file" onChange={handleFileChange} className="mb-4" />
+      <label htmlFor="resume-file" className="block mb-2 font-medium">
+        Select file
+      </label>
+      <input
+        id="resume-file"
+        type="file"
+        onChange={handleFileChange}
+        className="input-base mb-4"
+      />
       <button
         type="button"
         onClick={handleUpload}
         disabled={uploading}
-        className="btn-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+        className="btn-primary w-full"
       >
         {uploading ? "Uploading..." : "Upload"}
       </button>
 
       {url && (
         <p className="mt-4 text-sm">
-          ✅ File uploaded: <a href={url} target="_blank" className="text-blue-600">View Resume</a>
+          ✅ File uploaded: <a href={url} target="_blank" rel="noopener" className="text-primary underline">View resume</a>
         </p>
       )}
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,41 @@
 @import "tailwindcss";
 
-/* Saudi green + gold */
+/* Saudi-inspired theme tokens */
 @theme {
   --color-primary: #006C35; /* Saudi green */
   --color-secondary: #F5A623; /* gold */
+  --color-neutral-50: #FAFAF9;
+  --color-neutral-100: #F5F5F4;
+  --color-neutral-200: #E7E5E4;
+  --color-neutral-300: #D6D3D1;
+  --color-neutral-400: #A8A29E;
+  --color-neutral-500: #78716C;
+  --radius-card: 1rem; /* rounded-2xl */
+  --shadow-soft: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+@layer base {
+  body {
+    @apply bg-[--color-neutral-50] text-neutral-800 font-sans;
+  }
 }
 
 @utility btn {
-  @apply px-4 py-2 rounded-lg font-medium shadow-sm transition text-white;
+  @apply px-4 py-2 rounded-lg font-medium shadow-sm transition text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary;
+}
+
+@utility input-base {
+  @apply w-full border border-neutral-200 rounded-lg p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2;
+}
+
+@utility card {
+  @apply bg-white rounded-2xl shadow-soft p-6;
+}
+
+@layer utilities {
+  .shadow-soft {
+    box-shadow: var(--shadow-soft);
+  }
 }
 
 @layer components {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,24 @@ export default {
         primary: "#006C35",   // Saudi green
         secondary: "#C5A572", // Desert gold
         accent: "#1E293B",    // Slate
+        neutral: {
+          50: "#FAFAF9",
+          100: "#F5F5F4",
+          200: "#E7E5E4",
+          300: "#D6D3D1",
+          400: "#A8A29E",
+          500: "#78716C",
+          600: "#57534E",
+          700: "#44403C",
+          800: "#292524",
+          900: "#1C1917",
+        },
+      },
+      boxShadow: {
+        soft: "0 2px 4px rgba(0,0,0,0.05)",
+      },
+      borderRadius: {
+        '2xl': '1rem',
       },
     },
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   test: {
     environment: "happy-dom",        // <-- switch from jsdom
     globals: true,


### PR DESCRIPTION
## Summary
- enable Tailwind via Vite plugin so new neutral tokens and utilities render
- point index.html to TypeScript entry and mock Supabase in auth test

## Testing
- `npm ci --no-audit --no-fund`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c45f6adf488330b8d14733d7eeb8d3