### PR TITLE
fix(ui): dynamic skyline preload + gold shimmer badge

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -141,8 +141,6 @@ export default function Header() {
           ref={heroParallaxRef}
           className="relative h-full min-h-[100svh] w-full will-change-transform"
         >
-          import { skyline } from "@/lib/assets";
-          
           <img ref={heroImageRef} src={skyline()}
             alt=""
             width="1600"
@@ -218,9 +216,9 @@ export default function Header() {
           <div className="space-y-6">
             <span
               tabIndex={0}
-              className="badge-gold-shimmer inline-flex items-center gap-2 rounded-full border border-surface-50/30 bg-surface-50/20 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] text-surface-50 backdrop-blur-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-900"
+              className="badge-gold-shimmer inline-flex items-center gap-2 rounded-full border border-surface-50/30 bg-surface-50/20 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] backdrop-blur-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-900"
             >
-              Designed for Saudis ambition
+              Designed for Saudi ambition
             </span>
             <div className="relative">
               <span

--- a/src/index.css
+++ b/src/index.css
@@ -73,52 +73,40 @@
     animation: hero-fade-in 520ms ease-out forwards;
   }
 
-  @keyframes gold-shimmer {
-    0% {
-      transform: translate3d(-120%, 0, 0);
-    }
-
-    100% {
-      transform: translate3d(120%, 0, 0);
-    }
-  }
-
   .badge-gold-shimmer {
-    position: relative;
-    isolation: isolate;
-    overflow: hidden;
-    background-image: linear-gradient(120deg, rgba(197, 166, 106, 0.22), rgba(253, 230, 138, 0.12));
-    background-size: 140% 140%;
-    transition: background-position var(--duration-breathe) ease-out,
-      box-shadow var(--duration-snappy) var(--transition-snappy);
-  }
-
-  .badge-gold-shimmer::after {
-    content: "";
-    position: absolute;
-    inset: -20% -35%;
+    color: #c5a66a;
     background-image: linear-gradient(
-      128deg,
-      transparent 10%,
-      rgba(253, 230, 138, 0.05) 35%,
-      rgba(253, 230, 138, 0.45) 50%,
-      rgba(197, 166, 106, 0.4) 60%,
-      transparent 85%
+      120deg,
+      rgba(197, 166, 106, 0.35) 0%,
+      rgba(253, 230, 138, 0.55) 20%,
+      rgba(197, 166, 106, 0.35) 40%
     );
-    opacity: 0;
-    pointer-events: none;
-    transform: translate3d(-120%, 0, 0);
+    background-size: 200% auto;
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    animation: shimmer 3s linear infinite;
+    animation-play-state: paused;
   }
 
-  .badge-gold-shimmer:hover,
-  .badge-gold-shimmer:focus-visible {
-    background-position: 100% 0;
+  @supports not ((-webkit-background-clip: text) or (background-clip: text)) {
+    .badge-gold-shimmer {
+      color: #c5a66a;
+      background-image: none;
+    }
   }
 
-  .badge-gold-shimmer:hover::after,
-  .badge-gold-shimmer:focus-visible::after {
-    opacity: 1;
-    animation: gold-shimmer 2.8s linear infinite;
+  @keyframes shimmer {
+    to {
+      background-position: 200% center;
+    }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .badge-gold-shimmer:hover,
+    .badge-gold-shimmer:focus-visible {
+      animation-play-state: running;
+    }
   }
 
   .tab-pattern-hover {
@@ -160,10 +148,8 @@
       transform: none;
     }
 
-    .badge-gold-shimmer:hover::after,
-    .badge-gold-shimmer:focus-visible::after {
+    .badge-gold-shimmer {
       animation: none;
-      transform: translate3d(0, 0, 0);
     }
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
@@ -6,19 +6,35 @@ import { AuthProvider } from "./hooks/useAuth";
 import "./index.css";
 import { skyline } from "./lib/assets";
 
-// Preload skyline image at bootstrap
-const preloadLink = document.createElement("link");
-preloadLink.rel = "preload";
-preloadLink.as = "image";
-preloadLink.href = skyline();
-document.head.appendChild(preloadLink);
+const preloadSkyline = () => {
+  if (typeof document === "undefined") return;
+
+  const href = skyline();
+  const existing = document.head.querySelector<HTMLLinkElement>(
+    'link[data-preload="skyline"]',
+  );
+
+  if (existing) {
+    existing.href = href;
+    return;
+  }
+
+  const preloadLink = document.createElement("link");
+  preloadLink.rel = "preload";
+  preloadLink.as = "image";
+  preloadLink.href = href;
+  preloadLink.dataset.preload = "skyline";
+  document.head.appendChild(preloadLink);
+};
+
+preloadSkyline();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
+  <StrictMode>
     <BrowserRouter>
       <AuthProvider>
         <App />
       </AuthProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </StrictMode>
 );


### PR DESCRIPTION
## Context
- preload the skyline hero image at bootstrap via a guarded dynamic link to keep the asset hot without duplicating tags
- refresh the hero badge styling with a reusable gold shimmer utility that respects reduced-motion preferences and only animates on interaction

## Risk
- Low: touches bootstrap preload script and hero badge styles only.

## Testing
- npm run lint
- npm run test
- npm run build

## Screenshots
- N/A (hover shimmer animation is interactive and not captured in a static image)


------
https://chatgpt.com/codex/tasks/task_e_68cff1697eb48330b4854f78734da0ea