### PR TITLE
refactor(ui+ai): single-layer hero render, gold shimmer, preview messaging, gpt-5-nano defaults + max_completion_tokens alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Make your resume match the job—fast. Compare a resume to a job description and
 - Sends minimal text to the AI matcher (server function / API adapter)
 - Returns `{ score 0–100, missingKeywords[], suggestions[] }` to the UI
 
+## 🤖 AI defaults
+- OpenAI defaults (model + temperature) are centralized in [`netlify/lib/ai-config.ts`](netlify/lib/ai-config.ts).
+- Requests may provide `max_output_tokens` or the compatibility alias `max_completion_tokens`; the helper maps the alias once, clamps values between 1 and 4096, and logs a deprecation warning for local devs.
+
 ### analyzeResume(resumeText, jobText)
 
 Analyzes a resume against a job description and returns:

--- a/netlify/functions/optimize.ts
+++ b/netlify/functions/optimize.ts
@@ -1,10 +1,15 @@
 import type { Handler } from "@netlify/functions";
+import { resolveOpenAIOptions } from "../lib/ai-config";
 
 type OptimizeBody = {
   resumeText?: string;
   jobDesc?: string;
   mode?: "auto" | "conservative" | "aggressive";
   preview?: boolean;
+  model?: string;
+  temperature?: number;
+  max_output_tokens?: number;
+  max_completion_tokens?: number;
 };
 
 type OptimizationCard = {
@@ -33,7 +38,6 @@ const HEADERS = {
 } as const;
 
 const REQUEST_TIMEOUT = 15_000;
-const API_TEMPERATURE = 1;
 
 const STOPWORDS = new Set([
   "a",
@@ -253,9 +257,25 @@ const postToOpenAI = async (body: Record<string, unknown>, apiKey: string, timeo
 };
 
 const callOpenAI = async (payload: OptimizeBody, apiKey: string): Promise<OptimizationPayload> => {
-  const { resumeText = "", jobDesc = "", mode = "auto" } = payload;
+  const {
+    resumeText = "",
+    jobDesc = "",
+    mode = "auto",
+    model: modelOverride,
+    temperature: temperatureOverride,
+    max_output_tokens: maxOutputTokens,
+    max_completion_tokens: maxCompletionTokens,
+  } = payload;
   const prompt = buildPrompt(resumeText, jobDesc, mode);
-  const model = process.env.OPENAI_MODEL || "gpt-5-nano";
+  const requestOptions = resolveOpenAIOptions(
+    {
+      model: modelOverride,
+      temperature: temperatureOverride,
+      max_output_tokens: maxOutputTokens,
+      max_completion_tokens: maxCompletionTokens,
+    },
+    900,
+  );
   const messages = [
     {
       role: "system",
@@ -311,10 +331,8 @@ const callOpenAI = async (payload: OptimizeBody, apiKey: string): Promise<Optimi
   };
 
   const basePayload = {
-    model,
+    ...requestOptions,
     input: messages,
-    temperature: API_TEMPERATURE,
-    max_output_tokens: 900,
   } as const;
 
   try {

--- a/netlify/lib/ai-config.ts
+++ b/netlify/lib/ai-config.ts
@@ -1,0 +1,78 @@
+const FALLBACK_MODEL = "gpt-5-nano";
+const DEFAULT_TEMPERATURE = 1;
+const MIN_TOKENS = 1;
+const MAX_TOKENS = 4096;
+
+let aliasWarningLogged = false;
+
+export type OpenAIOptions = {
+  model?: string | null;
+  temperature?: number | null;
+  max_output_tokens?: number | null;
+  max_completion_tokens?: number | null;
+};
+
+const sanitizeModel = (value?: string | null): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const clampTokens = (value?: number | null): number | undefined => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (!Number.isFinite(rounded)) return undefined;
+  return Math.min(Math.max(rounded, MIN_TOKENS), MAX_TOKENS);
+};
+
+const getDefaultModel = () => sanitizeModel(process.env.OPENAI_MODEL) ?? FALLBACK_MODEL;
+
+export const getDefaultOpenAIConfig = () => ({
+  model: getDefaultModel(),
+  temperature: DEFAULT_TEMPERATURE,
+});
+
+export const resolveOpenAIOptions = (
+  overrides: OpenAIOptions = {},
+  fallbackMaxTokens?: number,
+) => {
+  const defaults = getDefaultOpenAIConfig();
+
+  const resolved: {
+    model: string;
+    temperature: number;
+    max_output_tokens?: number;
+  } = {
+    model: sanitizeModel(overrides.model) ?? defaults.model,
+    temperature:
+      typeof overrides.temperature === "number" && Number.isFinite(overrides.temperature)
+        ? overrides.temperature
+        : defaults.temperature,
+  };
+
+  let tokenValue = clampTokens(overrides.max_output_tokens ?? undefined);
+
+  const aliasValue = clampTokens(overrides.max_completion_tokens ?? undefined);
+  if (aliasValue !== undefined) {
+    if (!aliasWarningLogged) {
+      aliasWarningLogged = true;
+      console.warn(
+        "[ai-config] `max_completion_tokens` is deprecated. Use `max_output_tokens` to avoid future breaking changes.",
+      );
+    }
+    if (tokenValue === undefined) {
+      tokenValue = aliasValue;
+    }
+  }
+
+  const fallbackValue = clampTokens(fallbackMaxTokens ?? undefined);
+  if (tokenValue === undefined && fallbackValue !== undefined) {
+    tokenValue = fallbackValue;
+  }
+
+  if (tokenValue !== undefined) {
+    resolved.max_output_tokens = tokenValue;
+  }
+
+  return resolved;
+};

--- a/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
+++ b/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
@@ -116,7 +116,9 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
     </div>
     <input
       accept=".pdf,.docx"
+      aria-label="Upload resume file"
       class="sr-only"
+      title="Upload resume file"
       type="file"
     />
     <label

--- a/src/__tests__/aiConfig.test.ts
+++ b/src/__tests__/aiConfig.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadConfigModule = async () => import("../../netlify/lib/ai-config");
+
+describe("ai-config", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    delete process.env.OPENAI_MODEL;
+  });
+
+  it("returns defaults and applies fallback tokens", async () => {
+    const { resolveOpenAIOptions } = await loadConfigModule();
+    const options = resolveOpenAIOptions({}, 900);
+    expect(options.model).toBe("gpt-5-nano");
+    expect(options.temperature).toBe(1);
+    expect(options.max_output_tokens).toBe(900);
+  });
+
+  it("uses env override and clamps token requests", async () => {
+    process.env.OPENAI_MODEL = " custom-model ";
+    const { resolveOpenAIOptions } = await loadConfigModule();
+    const options = resolveOpenAIOptions({ max_output_tokens: 9999 }, 0);
+    expect(options.model).toBe("custom-model");
+    expect(options.max_output_tokens).toBe(4096);
+  });
+
+  it("maps the alias once and prefers explicit overrides", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { resolveOpenAIOptions } = await loadConfigModule();
+
+    const first = resolveOpenAIOptions({ max_completion_tokens: 2500 }, 0);
+    expect(first.max_output_tokens).toBe(2500);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    const second = resolveOpenAIOptions(
+      { max_completion_tokens: 3000, max_output_tokens: 1500 },
+      0,
+    );
+    expect(second.max_output_tokens).toBe(1500);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -65,12 +65,12 @@ export default function Header() {
   );
 
   return (
-    <header className="hero-bg-animate relative isolate flex flex-col justify-between gap-12 overflow-hidden bg-[#03120b] text-surface-50 min-h-[100svh] md:min-h-[100dvh] pb-16 sm:pb-24">
+    <header className="hero-bg-animate relative isolate flex min-h-screen flex-col justify-between gap-12 overflow-hidden bg-[#03120b] text-surface-50 min-h-[100svh] md:min-h-[100dvh] pb-16 sm:pb-24">
       {typeof skylineUrl === "string" && skylineUrl ? (
         <div
           aria-hidden="true"
           className={cn(
-            "bg-hero absolute inset-0 -z-40",
+            "bg-hero absolute inset-0 -z-40 pointer-events-none",
             animateSkyline ? "skyline-once" : "skyline-still"
           )}
           style={{
@@ -79,16 +79,16 @@ export default function Header() {
           }}
         />
       ) : null}
-      <div aria-hidden="true" className="absolute inset-0 -z-50">
-        <div className="absolute inset-0 bg-gradient-to-b from-[#031d12]/96 via-[#063321]/82 to-[#02130a]/96" />
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(32,201,151,0.25)_0%,rgba(3,20,13,0)_68%)]" />
+      <div aria-hidden="true" className="absolute inset-0 -z-30 pointer-events-none">
+        <div className="absolute inset-0 bg-gradient-to-b from-[#021d12]/96 via-[#043521]/86 to-[#01150a]/95" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(32,201,151,0.32)_0%,rgba(3,20,13,0)_68%)] mix-blend-screen" />
       </div>
       <div
-        className="absolute inset-0 -z-30 opacity-[0.05]"
+        className="absolute inset-0 -z-20 opacity-[0.08] mix-blend-soft-light"
         style={{ backgroundImage: `url("data:image/svg+xml,${saduPattern}")`, backgroundSize: "260px" }}
         aria-hidden="true"
       />
-      <div className="accent-divider absolute inset-x-0 bottom-0 -z-20 h-px" aria-hidden="true" />
+      <div className="accent-divider absolute inset-x-0 bottom-0 -z-10 h-px" aria-hidden="true" />
 
       <div className="relative z-10 flex flex-1 flex-col">
         <div className="border-b border-surface-50/10">
@@ -149,41 +149,41 @@ export default function Header() {
           <div className="space-y-6">
             <span
               tabIndex={0}
-              className="badge-gold-shimmer inline-flex items-center gap-2 rounded-full border border-surface-50/35 bg-surface-900/55 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] backdrop-blur-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent text-shadow-hero"
+              className="badge-gold-shimmer inline-flex items-center gap-2 rounded-full border border-surface-50/35 bg-surface-900/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] backdrop-blur-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent text-shadow-hero"
             >
               Designed for Saudi ambition
             </span>
-            <div className="relative max-w-2xl rounded-[var(--radius-card)] bg-surface-900/45 p-6 backdrop-blur-lg shadow-[0_32px_90px_-40px_rgba(0,0,0,0.55)]">
+            <div className="relative max-w-2xl rounded-[var(--radius-card)] bg-surface-900/55 p-6 backdrop-blur-2xl shadow-[0_32px_90px_-40px_rgba(0,0,0,0.6)]">
               <span
                 aria-hidden="true"
                 className="absolute -top-8 left-6 text-accent-400 drop-shadow-[0_0_18px_rgba(197,166,106,0.45)]"
               >
                 <Sparkles className="h-7 w-7" />
               </span>
-              <h1 className="text-shadow-hero text-4xl font-bold leading-tight tracking-tight drop-shadow-[0_14px_32px_rgba(0,0,0,0.55)] sm:text-5xl">
+              <h1 className="text-shadow-hero text-4xl font-bold leading-tight tracking-tight drop-shadow-[0_16px_34px_rgba(0,0,0,0.6)] sm:text-5xl">
                 AI Resume Optimizer
               </h1>
-              <p className="text-shadow-hero mt-4 max-w-xl text-base leading-relaxed text-surface-50/90">
+              <p className="text-shadow-hero mt-4 max-w-xl text-base leading-relaxed text-surface-50/95">
                 Transform your experience into a story. Our AI analyzes, matches, and optimizes your resume.
               </p>
             </div>
             <dl className="grid grid-cols-1 gap-4 text-left sm:grid-cols-3">
-              <div className="card-glow group rounded-2xl border border-surface-50/25 bg-surface-50/85 p-4 text-ink-700 shadow-sm backdrop-blur-sm transition-all duration-200 ease-out hover:bg-surface-50/90 hover:shadow-md dark:border-surface-50/10 dark:bg-surface-900/70 dark:text-surface-50 dark:hover:bg-surface-900/75">
+              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-white/80 p-4 text-ink-700 shadow-sm backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-md dark:border-surface-50/10 dark:bg-surface-900/60 dark:text-surface-50 dark:hover:bg-surface-900/70">
                 <dt className="text-[11px] font-semibold uppercase tracking-[0.32em] text-ink-500 dark:text-surface-50/70">Smart Parsing</dt>
                 <dd className="mt-2 text-lg font-semibold text-ink-900 dark:text-surface-50">Clean resume text</dd>
               </div>
-              <div className="card-glow group rounded-2xl border border-surface-50/25 bg-surface-50/85 p-4 text-ink-700 shadow-sm backdrop-blur-sm transition-all duration-200 ease-out hover:bg-surface-50/90 hover:shadow-md dark:border-surface-50/10 dark:bg-surface-900/70 dark:text-surface-50 dark:hover:bg-surface-900/75">
+              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-white/80 p-4 text-ink-700 shadow-sm backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-md dark:border-surface-50/10 dark:bg-surface-900/60 dark:text-surface-50 dark:hover:bg-surface-900/70">
                 <dt className="text-[11px] font-semibold uppercase tracking-[0.32em] text-ink-500 dark:text-surface-50/70">Match Score</dt>
                 <dd className="mt-2 text-lg font-semibold text-ink-900 dark:text-surface-50">Saudi market fit</dd>
               </div>
-              <div className="card-glow group rounded-2xl border border-surface-50/25 bg-surface-50/85 p-4 text-ink-700 shadow-sm backdrop-blur-sm transition-all duration-200 ease-out hover:bg-surface-50/90 hover:shadow-md dark:border-surface-50/10 dark:bg-surface-900/70 dark:text-surface-50 dark:hover:bg-surface-900/75">
+              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-white/80 p-4 text-ink-700 shadow-sm backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-md dark:border-surface-50/10 dark:bg-surface-900/60 dark:text-surface-50 dark:hover:bg-surface-900/70">
                 <dt className="text-[11px] font-semibold uppercase tracking-[0.32em] text-ink-500 dark:text-surface-50/70">Polished Output</dt>
                 <dd className="mt-2 text-lg font-semibold text-ink-900 dark:text-surface-50">Optimized insights</dd>
               </div>
             </dl>
           </div>
 
-          <div className="card-glow group rounded-[var(--radius-card)] border border-surface-50/25 bg-surface-50/85 p-6 text-ink-700 shadow-md backdrop-blur-sm transition-all duration-200 ease-out hover:bg-surface-50/90 hover:shadow-lg dark:border-surface-50/10 dark:bg-surface-900/70 dark:text-surface-50 dark:hover:bg-surface-900/75">
+          <div className="card-glow group rounded-[var(--radius-card)] border border-surface-50/20 bg-white/80 p-6 text-ink-700 shadow-md backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-lg dark:border-surface-50/10 dark:bg-surface-900/60 dark:text-surface-50 dark:hover:bg-surface-900/70">
             <h2 className="text-lg font-semibold tracking-wide text-ink-900 dark:text-surface-50">Your Saudi-ready workflow</h2>
             <ul className="mt-6 space-y-5 text-sm text-ink-500 dark:text-surface-50/85">
               <li className="flex gap-3">

--- a/src/components/shared/OptimizationCard.jsx
+++ b/src/components/shared/OptimizationCard.jsx
@@ -13,7 +13,7 @@ export default function OptimizationCard({ card, onCopy, disabledActions = false
   };
 
   return (
-    <article className="relative space-y-5 rounded-[var(--radius-card)] border border-secondary-500/12 bg-surface-50/85 p-6 shadow-soft backdrop-blur-xl dark:border-surface-50/10 dark:bg-surface-900/75">
+    <article className="relative space-y-5 rounded-[var(--radius-card)] border border-secondary-500/12 bg-white/80 p-6 shadow-soft backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-lg dark:border-surface-50/10 dark:bg-surface-900/65 dark:hover:bg-surface-900/70">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div className="flex items-center gap-3">
           <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-secondary-500/10 text-secondary-500">

--- a/src/components/ui/UploadCard.jsx
+++ b/src/components/ui/UploadCard.jsx
@@ -106,6 +106,8 @@ export default function UploadCard({
         type="file"
         accept=".pdf,.docx"
         className="sr-only"
+        aria-label="Upload resume file"
+        title="Upload resume file"
         onChange={handleFileChange}
       />
 

--- a/src/features/Optimization.jsx
+++ b/src/features/Optimization.jsx
@@ -33,7 +33,7 @@ const PreviewBanner = ({ onUpgrade }) => (
         </p>
         <div className="inline-flex items-center gap-2 rounded-full border border-secondary-500/20 bg-secondary-500/10 px-3 py-1 text-xs text-secondary-600 shadow-soft dark:border-surface-50/20 dark:bg-surface-900/60 dark:text-sand-50/70">
           <Info className="h-3.5 w-3.5" aria-hidden="true" />
-          <span className="leading-none">Try one detailed pass, then unlock premium storage.</span>
+          <span className="leading-none">Preview lets you test the flow. Upgrade to save/export.</span>
         </div>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -94,6 +94,7 @@
   }
 
   .badge-gold-shimmer {
+    position: relative;
     color: #c5a66a;
     background-image: linear-gradient(
       120deg,
@@ -101,12 +102,35 @@
       rgba(253, 230, 138, 0.55) 20%,
       rgba(197, 166, 106, 0.35) 40%
     );
-    background-size: 200% auto;
+    background-size: 220% auto;
     background-clip: text;
     -webkit-background-clip: text;
     color: transparent;
-    animation: shimmer 3s linear infinite;
+    animation: shimmer 2.8s linear infinite;
     animation-play-state: paused;
+    transition: filter 180ms ease, text-shadow 180ms ease;
+  }
+
+  .badge-gold-shimmer::after {
+    content: "";
+    position: absolute;
+    inset: -1px;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(197, 166, 106, 0) 25%, rgba(253, 230, 138, 0.45) 50%, rgba(197, 166, 106, 0) 75%);
+    opacity: 0;
+    transition: opacity 200ms ease;
+    pointer-events: none;
+  }
+
+  .badge-gold-shimmer:hover,
+  .badge-gold-shimmer:focus-visible {
+    animation-play-state: running;
+    filter: drop-shadow(0 0 12px rgba(197, 166, 106, 0.35));
+  }
+
+  .badge-gold-shimmer:hover::after,
+  .badge-gold-shimmer:focus-visible::after {
+    opacity: 0.25;
   }
 
   @supports not ((-webkit-background-clip: text) or (background-clip: text)) {
@@ -239,7 +263,7 @@
     background-size: cover;
     transform: scale(1.05);
     filter: saturate(1.05) brightness(0.96);
-    opacity: 0.9;
+    opacity: 0.84;
   }
 
   .bg-hero::after {
@@ -339,6 +363,11 @@
 
     .badge-gold-shimmer {
       animation: none;
+      filter: none;
+    }
+
+    .badge-gold-shimmer::after {
+      opacity: 0;
     }
 
     .skyline-once {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,31 +4,6 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { AuthProvider } from "./hooks/useAuth";
 import "./index.css";
-import { skyline } from "./lib/assets";
-
-const preloadSkyline = () => {
-  if (typeof document === "undefined") return;
-
-  const href = skyline();
-  const existing = document.head.querySelector<HTMLLinkElement>(
-    'link[data-preload="skyline"]',
-  );
-
-  if (existing) {
-    existing.href = href;
-    return;
-  }
-
-  const preloadLink = document.createElement("link");
-  preloadLink.rel = "preload";
-  preloadLink.as = "image";
-  preloadLink.href = href;
-  preloadLink.dataset.preload = "skyline";
-  document.head.appendChild(preloadLink);
-};
-
-preloadSkyline();
-
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>


### PR DESCRIPTION
## Context
- ensure the skyline background only renders through the existing hero layer while keeping gradients/patterns purely decorative and stretching the header to full viewport height for readability
- refresh hero surfaces with glassmorphism hover depth, add a reduced-motion aware gold shimmer accent on the badge, and clarify preview-mode helper copy while keeping cards accessible
- centralize OpenAI defaults in `netlify/lib/ai-config.ts`, support the `max_completion_tokens` alias with clamping and warning, and update server code/tests to consume the shared helper

## Risk
- Low: stylistic and configuration refactors with coverage from updated Vitest suite.

## Screenshots
- Not available in this environment.

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3291083e083309281803b001ec044