### PR TITLE
refactor(ui+ai): unify hero gradient and proxy OpenAI responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,22 @@ Make your resume match the job—fast. Compare a resume to a job description and
 
 ## 🤖 AI defaults
 - OpenAI defaults (model + temperature) are centralized in [`netlify/lib/ai-config.ts`](netlify/lib/ai-config.ts).
+- The Netlify proxy at [`/.netlify/functions/ai`](netlify/functions/ai.ts) calls the OpenAI Responses API with `model="gpt-5-nano"` and `temperature=1` unless overridden.
 - Requests may provide `max_output_tokens` or the compatibility alias `max_completion_tokens`; the helper maps the alias once, clamps values between 1 and 4096, and logs a deprecation warning for local devs.
+
+### Local AI proxy
+
+Run the Netlify function alongside Vite when developing locally:
+
+```bash
+# Install Netlify CLI if needed
+npm install -g netlify-cli
+
+# From the project root, start the dev server + functions
+netlify dev
+```
+
+The CLI proxies `/\.netlify/functions/ai` to the local TypeScript function so the app can hit the mocked OpenAI endpoint without additional configuration.
 
 ### analyzeResume(resumeText, jobText)
 

--- a/index.html
+++ b/index.html
@@ -45,12 +45,6 @@
         href="https://fonts.googleapis.com/css2?family=Tajawal:wght@400;500;700&display=swap"
       />
     </noscript>
-    <link
-      rel="preload"
-      as="image"
-      href="/images/KAFDHD.webp"
-      imagesrcset="/images/KAFDHD.webp 1x, /images/KAFDHD.jpg 2x"
-    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Resume Optimizer</title>
   </head>

--- a/netlify/functions/ai.ts
+++ b/netlify/functions/ai.ts
@@ -1,0 +1,193 @@
+import type { Handler } from "@netlify/functions";
+import { performance } from "node:perf_hooks";
+import { resolveOpenAIOptions } from "../lib/ai-config";
+
+const OPENAI_URL = "https://api.openai.com/v1/responses";
+const HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Content-Type": "application/json",
+} as const;
+
+const getRequestId = (event: Parameters<Handler>[0]) =>
+  event.headers?.["x-nf-request-id"] ?? crypto.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+
+const buildInput = (body: any) => {
+  if (Array.isArray(body?.input) && body.input.length > 0) {
+    return body.input;
+  }
+
+  if (Array.isArray(body?.messages) && body.messages.length > 0) {
+    return body.messages;
+  }
+
+  if (typeof body?.prompt === "string" && body.prompt.trim().length > 0) {
+    return [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: body.prompt,
+          },
+        ],
+      },
+    ];
+  }
+
+  if (typeof body?.text === "string" && body.text.trim().length > 0) {
+    return [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: body.text,
+          },
+        ],
+      },
+    ];
+  }
+
+  return null;
+};
+
+const extractOutputText = (data: any): string => {
+  if (!data) return "";
+  if (typeof data.output_text === "string") return data.output_text;
+  if (Array.isArray(data.output_text)) {
+    for (const entry of data.output_text) {
+      if (typeof entry === "string" && entry.trim().length > 0) {
+        return entry;
+      }
+    }
+  }
+  if (Array.isArray(data.output)) {
+    for (const item of data.output) {
+      const text =
+        (item?.content && Array.isArray(item.content) ? item.content[0]?.text : undefined) ?? item?.text;
+      if (typeof text === "string" && text.trim().length > 0) {
+        return text;
+      }
+    }
+  }
+  if (Array.isArray(data.choices)) {
+    const text = data.choices[0]?.message?.content;
+    if (typeof text === "string") {
+      return text;
+    }
+  }
+  return "";
+};
+
+const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return { statusCode: 200, headers: HEADERS, body: "" };
+  }
+
+  if (event.httpMethod !== "POST") {
+    return {
+      statusCode: 405,
+      headers: HEADERS,
+      body: JSON.stringify({ error: "Method not allowed" }),
+    };
+  }
+
+  const requestId = getRequestId(event);
+  const start = performance.now();
+
+  try {
+    const body = event.body ? JSON.parse(event.body) : {};
+    const input = buildInput(body);
+
+    if (!input) {
+      return {
+        statusCode: 400,
+        headers: HEADERS,
+        body: JSON.stringify({ error: "Request must include prompt, text, messages, or input." }),
+      };
+    }
+
+    const apiKey = process.env.OPENAI_API_KEY ?? process.env.VITE_OPENAI_KEY;
+    if (!apiKey) {
+      console.error("[ai] missing OPENAI_API_KEY", { requestId });
+      return {
+        statusCode: 503,
+        headers: HEADERS,
+        body: JSON.stringify({ error: "OpenAI is not configured." }),
+      };
+    }
+
+    const options = resolveOpenAIOptions(
+      {
+        model: body?.model,
+        temperature: body?.temperature,
+        max_output_tokens: body?.max_output_tokens,
+        max_completion_tokens: body?.max_completion_tokens,
+      },
+      typeof body?.fallback_max_tokens === "number" ? body.fallback_max_tokens : undefined,
+    );
+
+    const response = await fetch(OPENAI_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        ...options,
+        input,
+      }),
+    });
+
+    const data = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      const message = typeof data?.error?.message === "string" ? data.error.message : "OpenAI request failed";
+      const code = data?.error?.code;
+      console.error("[ai] request failed", {
+        requestId,
+        status: response.status,
+        code,
+        message,
+      });
+      return {
+        statusCode: response.status,
+        headers: HEADERS,
+        body: JSON.stringify({ error: message, code: code ?? null }),
+      };
+    }
+
+    const outputText = extractOutputText(data);
+    const latency = Math.round(performance.now() - start);
+    console.info("[ai] request complete", {
+      requestId,
+      model: options.model,
+      max_output_tokens: options.max_output_tokens ?? null,
+      latency_ms: latency,
+    });
+
+    return {
+      statusCode: 200,
+      headers: HEADERS,
+      body: JSON.stringify({
+        id: data?.id ?? null,
+        model: data?.model ?? options.model,
+        usage: data?.usage ?? null,
+        output_text: outputText,
+      }),
+    };
+  } catch (error) {
+    const latency = Math.round(performance.now() - start);
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("[ai] request error", { requestId, message, latency_ms: latency });
+    return {
+      statusCode: 500,
+      headers: HEADERS,
+      body: JSON.stringify({ error: message }),
+    };
+  }
+};
+
+export { handler };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,9 +3,15 @@ import MainContent from "./components/MainContent";
 
 export default function App() {
   return (
-    <>
-      <Header />
-      <MainContent />
-    </>
+    <div id="app-root" className="relative min-h-screen overflow-x-hidden">
+      <div aria-hidden="true" className="pointer-events-none fixed inset-0 -z-50">
+        <div className="absolute inset-0 bg-gradient-to-b from-emerald-950 via-emerald-900/95 to-emerald-800/90" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.18)_0%,rgba(6,78,59,0)_70%)]" />
+      </div>
+      <div className="relative flex min-h-screen flex-col">
+        <Header />
+        <MainContent />
+      </div>
+    </div>
   );
 }

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -65,7 +65,7 @@ export default function Header() {
   );
 
   return (
-    <header className="hero-bg-animate relative isolate flex min-h-screen flex-col justify-between gap-12 overflow-hidden bg-[#03120b] text-surface-50 min-h-[100svh] md:min-h-[100dvh] pb-16 sm:pb-24">
+    <header className="hero-bg-animate relative isolate flex min-h-screen flex-col justify-between gap-12 overflow-hidden text-surface-50 min-h-[100svh] md:min-h-[100dvh] pb-16 sm:pb-24">
       {typeof skylineUrl === "string" && skylineUrl ? (
         <div
           aria-hidden="true"
@@ -79,9 +79,16 @@ export default function Header() {
           }}
         />
       ) : null}
-      <div aria-hidden="true" className="absolute inset-0 -z-30 pointer-events-none">
-        <div className="absolute inset-0 bg-gradient-to-b from-[#021d12]/96 via-[#043521]/86 to-[#01150a]/95" />
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(32,201,151,0.32)_0%,rgba(3,20,13,0)_68%)] mix-blend-screen" />
+      <div
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-0 -z-30 pointer-events-none transition-colors duration-700",
+          isDark
+            ? "bg-gradient-to-b from-black/50 via-emerald-900/40 to-emerald-950/60"
+            : "bg-gradient-to-b from-emerald-700/40 via-transparent to-emerald-900/35",
+        )}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(32,201,151,0.3)_0%,rgba(3,20,13,0)_70%)] mix-blend-screen" />
       </div>
       <div
         className="absolute inset-0 -z-20 opacity-[0.08] mix-blend-soft-light"

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -56,7 +56,9 @@ export default function MainContent() {
   const [isOptimizing, setIsOptimizing] = useState(false);
   const [previewUsed, setPreviewUsed] = useState(false);
   const [toasts, setToasts] = useState([]);
+  const [aiDebug, setAiDebug] = useState(null);
   const toastTimers = useRef(new Map());
+  const isDev = import.meta.env.MODE === "development";
 
   const dismissToast = useCallback((id) => {
     setToasts((prev) => prev.filter((toast) => toast.id !== id));
@@ -251,12 +253,30 @@ export default function MainContent() {
           { id: TOAST_IDS.optimize }
         );
 
-        const result = await optimizeResume({
-          resumeText: resumeData,
-          jobDesc: jobDescription,
-          mode,
-          preview: !isPremium,
-        });
+        const result = await optimizeResume(
+          {
+            resumeText: resumeData,
+            jobDesc: jobDescription,
+            mode,
+            preview: !isPremium,
+          },
+          {
+            onDebug: setAiDebug,
+            onError: (error) => {
+              pushToast(
+                {
+                  type: "danger",
+                  title: "Optimization failed",
+                  description: withTemperature(
+                    (error?.message || "Please try again shortly.") +
+                      " • Save your best bullets before retrying.",
+                  ),
+                },
+                { id: TOAST_IDS.optimize }
+              );
+            },
+          }
+        );
 
         setOptimizations(result.cards ?? []);
         setOptimizationKeywords(result.keywords ?? { add: [], remove: [], neutral: [] });
@@ -282,17 +302,6 @@ export default function MainContent() {
         return result;
       } catch (error) {
         setFlowProgress(0);
-        pushToast(
-          {
-            type: "danger",
-            title: "Optimization failed",
-            description: withTemperature(
-              (error?.message || "Please try again shortly.") +
-                " • Save your best bullets before retrying."
-            ),
-          },
-          { id: TOAST_IDS.optimize }
-        );
         throw error;
       } finally {
         setIsOptimizing(false);
@@ -416,53 +425,75 @@ export default function MainContent() {
   );
 
   return (
-    <>
-      <div aria-hidden="true" className="pointer-events-none fixed inset-0 -z-50">
-        <div className="absolute inset-0 bg-gradient-to-b from-[#052618]/94 via-[#04311f]/84 to-[#02130b]/96" />
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(32,201,151,0.22)_0%,rgba(3,20,13,0)_68%)]" />
-        <div className="accent-divider absolute inset-x-0 bottom-0 z-0 h-px" aria-hidden="true" />
-      </div>
-      <main
-        data-app-main
-        className="relative z-10 -mt-20 min-h-screen px-4 pb-32 pt-24 sm:px-6 lg:pb-40"
-      >
-        <ToastContainer>{renderedToasts}</ToastContainer>
-        <div className="mx-auto max-w-6xl">
-          <div className="card-glow rounded-[var(--radius-card)] border border-secondary-500/12 bg-surface-50/94 p-8 shadow-card backdrop-blur-xl transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_24px_70px_-42px_rgba(15,15,18,0.58)] dark:border-surface-50/12 dark:bg-surface-900/82">
-            {flowProgress > 0 && (
-              <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-smoke-50/70 dark:bg-surface-900/70">
-                <div
-                  className="h-full rounded-full bg-gradient-to-r from-primary-500 via-primary-600 to-primary-700 transition-all duration-300"
-                  style={{ width: `${flowProgress}%` }}
-                  aria-hidden="true"
-                />
-              </div>
-            )}
-
-            {loading ? (
-              <div className="space-y-6">
-                <div className="h-8 w-40 rounded-full bg-smoke-50/70" />
-                <div className="h-96 w-full overflow-hidden rounded-[var(--radius-card)] bg-smoke-50/60">
-                  <div className="h-full w-1/2 animate-shimmer bg-gradient-to-r from-transparent via-surface-50/40 to-transparent" />
-                </div>
-              </div>
-            ) : user ? (
-              workspace
-            ) : (
-              <EmptyState
-                icon={UserPlus}
-                title="Sign in to unlock Saudi-ready insights"
-                description="Connect your account to securely upload resumes, run match analysis, and save optimization drafts."
-                actions={
-                  <PrimaryButton icon={LogIn} onClick={signInWithGoogle}>
-                    Sign in via Google
-                  </PrimaryButton>
-                }
+    <main data-app-main className="relative z-10 -mt-24 min-h-screen px-4 pb-32 pt-24 sm:px-6 lg:pb-40">
+      <ToastContainer>{renderedToasts}</ToastContainer>
+      <div className="mx-auto max-w-6xl">
+        <div className="card-glow rounded-[var(--radius-card)] border border-secondary-500/12 bg-surface-50/94 p-8 shadow-card backdrop-blur-xl transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_24px_70px_-42px_rgba(15,15,18,0.58)] dark:border-surface-50/12 dark:bg-surface-900/82">
+          {flowProgress > 0 && (
+            <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-smoke-50/70 dark:bg-surface-900/70">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-primary-500 via-primary-600 to-primary-700 transition-all duration-300"
+                style={{ width: `${flowProgress}%` }}
+                aria-hidden="true"
               />
-            )}
-          </div>
+            </div>
+          )}
+
+          {loading ? (
+            <div className="space-y-6">
+              <div className="h-8 w-40 rounded-full bg-smoke-50/70" />
+              <div className="h-96 w-full overflow-hidden rounded-[var(--radius-card)] bg-smoke-50/60">
+                <div className="h-full w-1/2 animate-shimmer bg-gradient-to-r from-transparent via-surface-50/40 to-transparent" />
+              </div>
+            </div>
+          ) : user ? (
+            workspace
+          ) : (
+            <EmptyState
+              icon={UserPlus}
+              title="Sign in to unlock Saudi-ready insights"
+              description="Connect your account to securely upload resumes, run match analysis, and save optimization drafts."
+              actions={
+                <PrimaryButton icon={LogIn} onClick={signInWithGoogle}>
+                  Sign in via Google
+                </PrimaryButton>
+              }
+            />
+          )}
         </div>
-      </main>
-    </>
+        {isDev && aiDebug && (
+          <section className="mt-6 text-xs text-ink-500 dark:text-surface-50/70">
+            <div className="rounded-[var(--radius-card)] border border-secondary-500/20 bg-surface-50/90 p-4 shadow-soft backdrop-blur-xl dark:border-surface-50/15 dark:bg-surface-900/70">
+              <p className="font-semibold uppercase tracking-[0.24em] text-secondary-500">AI Debug</p>
+              <dl className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <div>
+                  <dt className="text-[10px] uppercase tracking-[0.24em] text-ink-500/70 dark:text-surface-50/60">Status</dt>
+                  <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">{aiDebug.status}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] uppercase tracking-[0.24em] text-ink-500/70 dark:text-surface-50/60">Model</dt>
+                  <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">{aiDebug.model ?? "–"}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] uppercase tracking-[0.24em] text-ink-500/70 dark:text-surface-50/60">Tokens</dt>
+                  <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">{aiDebug.tokens ?? "–"}</dd>
+                </div>
+                <div>
+                  <dt className="text-[10px] uppercase tracking-[0.24em] text-ink-500/70 dark:text-surface-50/60">Latency</dt>
+                  <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">
+                    {aiDebug.latencyMs ? `${Math.round(aiDebug.latencyMs)} ms` : "–"}
+                  </dd>
+                </div>
+              </dl>
+              {aiDebug.requestId && (
+                <p className="mt-3 break-words text-[10px] text-ink-400/80 dark:text-surface-50/50">
+                  Request ID: {aiDebug.requestId}
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -266,14 +266,6 @@
     opacity: 0.84;
   }
 
-  .bg-hero::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(to top, rgba(3, 18, 11, 0.85) 4%, rgba(3, 27, 17, 0.62) 42%, rgba(3, 21, 12, 0.05) 78%),
-      radial-gradient(circle at 22% -10%, rgba(32, 201, 151, 0.36) 0%, rgba(3, 20, 13, 0) 60%);
-  }
-
   @media (max-width: 1024px) {
     .bg-hero {
       --hero-skyline-offset: calc(100% - clamp(200px, 30vh, 340px));

--- a/src/lib/aiClient.ts
+++ b/src/lib/aiClient.ts
@@ -1,0 +1,113 @@
+const AI_ENDPOINT = "/.netlify/functions/ai";
+const USE_MOCK = import.meta.env.VITE_USE_MOCK_AI === "true";
+
+export type RunOptimizationPayload = Record<string, unknown>;
+
+export type RunOptimizationDebug = {
+  status: "success" | "error";
+  model?: string | null;
+  tokens?: number | null;
+  latencyMs?: number;
+  requestId?: string | null;
+};
+
+export type RunOptimizationOptions = {
+  signal?: AbortSignal;
+  // eslint-disable-next-line no-unused-vars
+  onError?: (error: Error) => void;
+  // eslint-disable-next-line no-unused-vars
+  onDebug?: (info: RunOptimizationDebug) => void;
+};
+
+export type RunOptimizationResponse = {
+  text: string;
+  raw: any;
+};
+
+const canUseMock = () => import.meta.env.MODE === "development" && USE_MOCK;
+
+const parseError = (payload: any): string => {
+  if (!payload || typeof payload !== "object") return "Request failed";
+  if (typeof payload.error === "string" && payload.error.trim().length > 0) return payload.error;
+  if (typeof payload.message === "string" && payload.message.trim().length > 0) return payload.message;
+  return "Request failed";
+};
+
+export async function runOptimization(
+  payload: RunOptimizationPayload,
+  options: RunOptimizationOptions = {},
+): Promise<RunOptimizationResponse> {
+  const now = () => (typeof performance !== "undefined" ? performance.now() : Date.now());
+  const started = now();
+  const controller = new AbortController();
+  const signal = options.signal;
+
+  const abortHandler = () => {
+    controller.abort();
+    signal?.removeEventListener?.("abort", abortHandler);
+  };
+  signal?.addEventListener?.("abort", abortHandler);
+
+  try {
+    const response = await fetch(AI_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload ?? {}),
+      signal: controller.signal,
+    });
+
+    const data = await response.json().catch(() => ({}));
+    const latencyMs = now() - started;
+
+    if (!response.ok) {
+      const message = parseError(data);
+      const error = new Error(message);
+      options.onDebug?.({ status: "error", model: payload?.model as string | undefined, latencyMs });
+      options.onError?.(error);
+      throw error;
+    }
+
+    const text = typeof data?.output_text === "string" ? data.output_text : "";
+    const tokens =
+      typeof data?.usage?.output_tokens === "number"
+        ? data.usage.output_tokens
+        : typeof data?.usage?.total_tokens === "number"
+        ? data.usage.total_tokens
+        : null;
+
+    options.onDebug?.({
+      status: "success",
+      model: typeof data?.model === "string" ? data.model : (payload?.model as string | undefined) ?? null,
+      tokens: tokens ?? null,
+      latencyMs,
+      requestId: typeof data?.id === "string" ? data.id : null,
+    });
+
+    return { text, raw: data };
+  } catch (error) {
+    const latencyMs = now() - started;
+    const normalized =
+      error instanceof Error
+        ? error
+        : new Error(typeof error === "string" ? error : "Unable to reach AI service");
+    options.onDebug?.({
+      status: "error",
+      model: (payload?.model as string | undefined) ?? null,
+      latencyMs,
+    });
+    if (normalized.name === "AbortError") {
+      normalized.message = "AI request timed out";
+    }
+    options.onError?.(normalized);
+
+    if (canUseMock()) {
+      return { text: "", raw: null };
+    }
+
+    throw normalized;
+  } finally {
+    signal?.removeEventListener?.("abort", abortHandler);
+  }
+}
+
+export { USE_MOCK };

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,9 +1,165 @@
 // src/services/api.js
 
+import { runOptimization, USE_MOCK } from "../lib/aiClient";
+
 const FUNCTION_BASE_PATH = "/.netlify/functions";
 const MATCH_ENDPOINT = `${FUNCTION_BASE_PATH}/match-score`;
-const OPTIMIZE_ENDPOINT = `${FUNCTION_BASE_PATH}/optimize`;
 const REQUEST_TIMEOUT = 15000;
+
+const sanitize = (value) => {
+  let buffer = "";
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    buffer += code < 32 || code === 127 ? " " : char;
+  }
+  return buffer.trim();
+};
+
+const tokenize = (input) =>
+  input
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .match(/[a-z0-9]+/g)
+    ?.filter((token) => !STOPWORDS.has(token) && token.length > 2) ?? [];
+
+const pickKeywords = (jobDesc, resumeText) => {
+  const jobTokens = tokenize(jobDesc);
+  const resumeTokens = new Set(tokenize(resumeText));
+  const counts = new Map();
+  for (const token of jobTokens) {
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  const ranked = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  const add = [];
+  const neutral = [];
+  for (const [token] of ranked) {
+    if (add.length < 6 && !resumeTokens.has(token)) {
+      add.push(token);
+    } else if (neutral.length < 6 && resumeTokens.has(token)) {
+      neutral.push(token);
+    }
+    if (add.length >= 6 && neutral.length >= 6) break;
+  }
+  return { add, neutral, remove: [] };
+};
+
+const buildMockCards = (resumeText, jobDesc, mode) => {
+  const keywords = pickKeywords(jobDesc, resumeText);
+  const toneMap = {
+    auto: "balanced",
+    conservative: "measured",
+    aggressive: "impactful",
+  };
+  const tone = toneMap[mode ?? "auto"] ?? "balanced";
+  const baseSections = ["Summary", "Experience", "Skills", "Achievements", "Leadership"];
+  const cards = baseSections.slice(0, 4).map((section, index) => {
+    const keyword = keywords.add[index] ?? keywords.neutral[index] ?? "impact";
+    const descriptor = tone === "impactful" ? "powerful" : tone === "measured" ? "grounded" : "clear";
+    return {
+      section,
+      issue: `${section} lacks a ${descriptor} mention of ${keyword}.`,
+      suggestion: `Integrate a ${descriptor} bullet that highlights ${keyword} with metrics tied to Saudi market outcomes.`,
+      exampleBefore: `Led initiatives without explicit ${keyword} framing.`,
+      exampleAfter: `Orchestrated ${keyword}-focused programs that delivered 18% uplift in product adoption across Riyadh.`,
+    };
+  });
+
+  if (cards.length < 3) {
+    cards.push({
+      section: "Summary",
+      issue: "Summary feels generic for Saudi employers.",
+      suggestion: "Anchor the opening statement to digital transformation outcomes and Vision 2030 alignment.",
+      exampleBefore: "Experienced professional seeking new opportunities.",
+      exampleAfter: "Saudi fintech strategist translating Vision 2030 mandates into scalable, customer-first platforms.",
+    });
+  }
+
+  return {
+    cards,
+    keywords,
+    source: "mock",
+  };
+};
+
+const safeJson = (value) => {
+  if (typeof value !== "string") return {};
+  const start = value.indexOf("{");
+  const end = value.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    const segment = value.slice(start, end + 1);
+    try {
+      return JSON.parse(segment);
+    } catch {
+      return {};
+    }
+  }
+  return {};
+};
+
+const toPayload = (value) => {
+  const fallback = buildMockCards("", "", "auto");
+  if (!value || typeof value !== "object") return fallback;
+  const maybe = value;
+  const cards = Array.isArray(maybe.cards)
+    ? maybe.cards
+        .slice(0, 6)
+        .map((card) => ({
+          section: sanitize(String(card.section ?? "Summary")),
+          issue: sanitize(String(card.issue ?? "")),
+          suggestion: sanitize(String(card.suggestion ?? "")),
+          exampleBefore: sanitize(String(card.exampleBefore ?? "")),
+          exampleAfter: sanitize(String(card.exampleAfter ?? "")),
+        }))
+        .filter((card) => card.suggestion.length > 0)
+    : fallback.cards;
+
+  const keywords = maybe.keywords && typeof maybe.keywords === "object"
+    ? {
+        add: Array.isArray(maybe.keywords.add)
+          ? maybe.keywords.add.map((item) => sanitize(String(item))).filter(Boolean).slice(0, 10)
+          : [],
+        remove: Array.isArray(maybe.keywords.remove)
+          ? maybe.keywords.remove.map((item) => sanitize(String(item))).filter(Boolean).slice(0, 10)
+          : [],
+        neutral: Array.isArray(maybe.keywords.neutral)
+          ? maybe.keywords.neutral.map((item) => sanitize(String(item))).filter(Boolean).slice(0, 10)
+          : [],
+      }
+    : fallback.keywords;
+
+  return {
+    cards: cards.length > 0 ? cards : fallback.cards,
+    keywords,
+    source: maybe.source === "openai" ? "openai" : fallback.source,
+  };
+};
+
+const STOPWORDS = new Set([
+  "a",
+  "about",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "has",
+  "in",
+  "into",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "their",
+  "to",
+  "with",
+]);
 
 const createTimeoutController = (timeout = REQUEST_TIMEOUT) => {
   const controller = new AbortController();
@@ -88,7 +244,10 @@ export const analyzeResume = async (resumeText, jobText, options = {}) => {
   }
 };
 
-export const optimizeResume = async ({ resumeText, jobDesc, mode = "auto", preview = false }) => {
+export const optimizeResume = async (
+  { resumeText, jobDesc, mode = "auto", preview = false },
+  clientOptions = {},
+) => {
   const resume = sanitizeText(resumeText);
   const job = sanitizeText(jobDesc);
 
@@ -97,25 +256,43 @@ export const optimizeResume = async ({ resumeText, jobDesc, mode = "auto", previ
   }
 
   const { controller, timer } = createTimeoutController();
+  const canUseMock = import.meta.env.MODE === "development" && USE_MOCK;
 
   try {
-    const response = await fetch(OPTIMIZE_ENDPOINT, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ resumeText: resume, jobDesc: job, mode, preview }),
-      signal: controller.signal,
-    });
+    const result = await runOptimization(
+      {
+        resumeText: resume,
+        jobDesc: job,
+        mode,
+        preview,
+      },
+      {
+        signal: controller.signal,
+        onError: clientOptions.onError,
+        onDebug: clientOptions.onDebug,
+      },
+    );
 
-    const data = await handleResponse(response);
+    if (!result.text) {
+      if (canUseMock) {
+        const fallback = buildMockCards(resume, job, mode);
+        clientOptions.onDebug?.({ status: "success", model: "mock", tokens: null });
+        return fallback;
+      }
+      throw new Error("AI response was empty.");
+    }
 
-    return {
-      cards: Array.isArray(data?.cards) ? data.cards : [],
-      keywords: data?.keywords ?? { add: [], remove: [], neutral: [] },
-      source: data?.source ?? "mock",
-    };
+    const parsed = safeJson(result.text);
+    const payload = toPayload(parsed);
+    return { ...payload, source: "openai" };
   } catch (error) {
     if (error?.name === "AbortError") {
       throw new Error("Optimization request timed out. Try again shortly.");
+    }
+    if (canUseMock) {
+      const fallback = buildMockCards(resume, job, mode);
+      clientOptions.onDebug?.({ status: "success", model: "mock", tokens: null });
+      return fallback;
     }
     throw error;
   } finally {

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -1,4 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../lib/aiClient', () => {
+  const runOptimization = vi.fn();
+  return {
+    runOptimization,
+    USE_MOCK: false,
+  };
+});
+
+import { runOptimization } from '../lib/aiClient';
 import { analyzeResume, optimizeResume, parseResume } from './api.js';
 
 beforeEach(() => {
@@ -63,23 +73,22 @@ describe('analyzeResume', () => {
 });
 
 describe('optimizeResume', () => {
-  it('returns cards from optimize function', async () => {
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          cards: [
-            {
-              section: 'Summary',
-              issue: 'Issue',
-              suggestion: 'Fix it',
-              exampleBefore: 'Before',
-              exampleAfter: 'After',
-            },
-          ],
-          keywords: { add: ['react'], remove: [], neutral: [] },
-          source: 'mock',
-        }),
+  it('parses AI response into cards and keywords', async () => {
+    runOptimization.mockResolvedValueOnce({
+      text: JSON.stringify({
+        cards: [
+          {
+            section: 'Summary',
+            issue: 'Issue',
+            suggestion: 'Fix it',
+            exampleBefore: 'Before',
+            exampleAfter: 'After',
+          },
+        ],
+        keywords: { add: ['react'], remove: [], neutral: [] },
+        source: 'openai',
+      }),
+      raw: { id: 'req_123', model: 'gpt-5-nano' },
     });
 
     const result = await optimizeResume({
@@ -88,17 +97,19 @@ describe('optimizeResume', () => {
       mode: 'auto',
     });
 
-    expect(global.fetch).toHaveBeenCalledWith('/.netlify/functions/optimize', expect.objectContaining({
-      method: 'POST',
-    }));
+    expect(runOptimization).toHaveBeenCalledWith(
+      expect.objectContaining({ resumeText: 'resume', jobDesc: 'job', mode: 'auto' }),
+      expect.objectContaining({ signal: expect.any(Object) })
+    );
     expect(result.cards).toHaveLength(1);
     expect(result.keywords.add).toContain('react');
+    expect(result.source).toBe('openai');
   });
 
   it('throws when request aborted', async () => {
     const abortError = new Error('Aborted');
     abortError.name = 'AbortError';
-    global.fetch.mockRejectedValueOnce(abortError);
+    runOptimization.mockRejectedValueOnce(abortError);
 
     await expect(
       optimizeResume({ resumeText: 'resume', jobDesc: 'job', mode: 'auto' })


### PR DESCRIPTION
## Summary
- move the page gradient to the app root and drop the legacy Netlify skyline preload
- adjust the hero overlay and main content to honor light/dark themes and add a dev-only AI debug panel
- proxy resume optimizations through a new Netlify OpenAI function and shared client helper

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3c8f0a0fc8330b38237af2d887c4f