### PR TITLE
Remove stale skyline fallbacks and add build cache busting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,7 @@ export default [
   js.configs.recommended,
 
   {
-    files: ["**/*.{js,jsx,ts,tsx}"],
+    files: ["**/*.{js,jsx,ts,tsx,mjs}"],
     languageOptions: {
       parser: parserTs,
       ecmaVersion: "latest",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node scripts/build.mjs",
+    "build:vite": "vite build",
     "preview": "vite preview",
     "lint": "eslint .",
     "test": "vitest run"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,12 @@
+/* eslint-env node */
+import { build } from "vite";
+
+process.env.VITE_BUILD_ID = Date.now().toString();
+
+try {
+  await build();
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}
+

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadModule = async () => import("./assets");
+
+describe("withVersion", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("appends the build version when available", async () => {
+    vi.stubEnv("VITE_BUILD_ID", "123");
+    const { withVersion } = await loadModule();
+    expect(withVersion("https://example.com/hero.webp")).toBe(
+      "https://example.com/hero.webp?v=123",
+    );
+  });
+
+  it("returns the original url when no build id is provided", async () => {
+    const { withVersion } = await loadModule();
+    expect(withVersion("https://example.com/hero.webp")).toBe(
+      "https://example.com/hero.webp",
+    );
+  });
+});
+
+describe("asset", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("normalizes the configured asset base", async () => {
+    vi.stubEnv("VITE_ASSETS_BASE_URL", "https://cdn.example.com/media/");
+    const { asset } = await loadModule();
+    expect(asset("/KAFDHD.webp")).toBe("https://cdn.example.com/media/KAFDHD.webp");
+  });
+});

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,14 +1,36 @@
 // src/lib/assets.ts
-const base = (import.meta as any).env.VITE_ASSETS_BASE_URL?.replace(/\/$/, "") || "";
+const base = import.meta.env.VITE_ASSETS_BASE_URL?.replace(/\/$/, "") ?? "";
+const devFallbackBase = import.meta.env.DEV ? "/images" : "";
 
-export const asset = (p: string) => (base ? `${base}/${p.replace(/^\//, "")}` : `/images/${p}`);
+const normalize = (p: string) => p.replace(/^\//, "");
+
+export const asset = (p: string) => {
+  const normalized = normalize(p);
+  if (base) {
+    return `${base}/${normalized}`;
+  }
+  if (devFallbackBase) {
+    return `${devFallbackBase}/${normalized}`;
+  }
+  return `/${normalized}`;
+};
+
+export const withVersion = (u: string) => {
+  const buildId = import.meta.env.VITE_BUILD_ID;
+  if (!buildId) {
+    return u;
+  }
+  return `${u}${u.includes("?") ? "&" : "?"}v=${buildId}`;
+};
 
 export const skyline = () => {
   // Try .webp, fall back to .jpg automatically
-  const webp = asset("KAFDHD.webp");
-  const jpg  = asset("KAFDHD.jpg");
+  const webp = withVersion(asset("KAFDHD.webp"));
+  const jpg = withVersion(asset("KAFDHD.jpg"));
   // simple runtime webp support sniff (most modern browsers support it)
-  const canWebP = typeof document !== "undefined" ? document.createElement("canvas")
-    .toDataURL?.("image/webp").startsWith("data:image/webp") : true;
+  const canWebP = typeof document !== "undefined"
+    ? document.createElement("canvas").toDataURL?.("image/webp").startsWith("data:image/webp")
+    : true;
   return canWebP ? webp : jpg;
 };
+


### PR DESCRIPTION
## Summary
- update skyline asset helper to drop legacy /images fallbacks and append build-scoped cache busting
- add build script that seeds VITE_BUILD_ID and extend lint config plus tests for the helper
- verify production bundle no longer emits /images/KAFD*.webp references while keeping hero loading logic intact

## Context
Legacy Netlify references were still being injected into the production bundle, so we now rely on the configured asset base (with a dev-only fallback) and add versioned URLs for the hero image.

## Risk
- Low: touches asset URL helpers and build tooling; covered by automated tests and manual bundle inspection.

## Testing
- npm run lint
- npm run test
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d4215b60dc8330aa1132f17fdb1d34