### PR TITLE
feat: layout polish and hero cache bust

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,10 +4,6 @@ import MainContent from "./components/MainContent";
 export default function App() {
   return (
     <div id="app-root" className="relative min-h-screen overflow-x-hidden">
-      <div aria-hidden="true" className="pointer-events-none fixed inset-0 -z-50">
-        <div className="absolute inset-0 bg-gradient-to-b from-emerald-950 via-emerald-900/95 to-emerald-800/90" />
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.18)_0%,rgba(6,78,59,0)_70%)]" />
-      </div>
       <div className="relative flex min-h-screen flex-col">
         <Header />
         <MainContent />

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -65,7 +65,7 @@ export default function Header() {
   );
 
   return (
-    <header className="hero-bg-animate relative isolate flex min-h-screen flex-col justify-between gap-12 overflow-hidden text-surface-50 min-h-[100svh] md:min-h-[100dvh] pb-16 sm:pb-24">
+    <header className="hero-bg-animate relative isolate flex min-h-screen min-h-[100svh] flex-col justify-between gap-10 overflow-hidden pb-16 text-surface-50 sm:gap-12 sm:pb-20 lg:min-h-[100dvh]">
       {typeof skylineUrl === "string" && skylineUrl ? (
         <div
           aria-hidden="true"
@@ -99,8 +99,8 @@ export default function Header() {
 
       <div className="relative z-10 flex flex-1 flex-col">
         <div className="border-b border-surface-50/10">
-          <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
-            <div className="flex items-center gap-3">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-[var(--page-gutter)] py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3 text-center sm:text-left">
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-surface-50/10 text-accent-500 shadow-soft">
                 <Sparkles className="h-5 w-5" aria-hidden="true" />
               </span>
@@ -113,7 +113,7 @@ export default function Header() {
                 </p>
               </div>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-end">
               <div role="radiogroup" aria-label="Color theme" className={toggleGroupClass}>
                 {themeOptions.map(({ value, label, icon: Icon }, index) => {
                   const isActive = theme === value;
@@ -152,25 +152,25 @@ export default function Header() {
           </div>
         </div>
 
-        <div className="mx-auto grid w-full max-w-6xl flex-1 items-center gap-12 px-6 pb-16 pt-12 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+        <div className="mx-auto grid w-full max-w-6xl flex-1 items-center gap-8 px-[var(--page-gutter)] pb-14 pt-12 sm:gap-10 sm:pb-16 sm:pt-16 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] lg:gap-12 lg:pb-20">
           <div className="space-y-6">
             <span
               tabIndex={0}
-              className="badge-gold-shimmer inline-flex items-center gap-2 rounded-full border border-surface-50/35 bg-surface-900/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] backdrop-blur-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent text-shadow-hero"
+              className="badge-gold-shimmer inline-flex items-center gap-2 self-center rounded-full border border-surface-50/35 bg-surface-900/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] backdrop-blur-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent text-shadow-hero sm:self-start"
             >
               Designed for Saudi ambition
             </span>
-            <div className="relative max-w-2xl rounded-[var(--radius-card)] bg-surface-900/55 p-6 backdrop-blur-2xl shadow-[0_32px_90px_-40px_rgba(0,0,0,0.6)]">
+            <div className="relative max-w-2xl rounded-[var(--radius-card)] bg-surface-900/55 p-5 backdrop-blur-2xl shadow-[0_32px_90px_-40px_rgba(0,0,0,0.6)] sm:p-6">
               <span
                 aria-hidden="true"
                 className="absolute -top-8 left-6 text-accent-400 drop-shadow-[0_0_18px_rgba(197,166,106,0.45)]"
               >
                 <Sparkles className="h-7 w-7" />
               </span>
-              <h1 className="text-shadow-hero text-4xl font-bold leading-tight tracking-tight drop-shadow-[0_16px_34px_rgba(0,0,0,0.6)] sm:text-5xl">
+              <h1 className="text-balance text-shadow-hero text-4xl font-bold leading-tight tracking-tight drop-shadow-[0_16px_34px_rgba(0,0,0,0.6)] sm:text-5xl">
                 AI Resume Optimizer
               </h1>
-              <p className="text-shadow-hero mt-4 max-w-xl text-base leading-relaxed text-surface-50/95">
+              <p className="text-pretty text-shadow-hero mt-4 max-w-xl text-base leading-relaxed text-surface-50/95">
                 Transform your experience into a story. Our AI analyzes, matches, and optimizes your resume.
               </p>
             </div>

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -421,10 +421,10 @@ export default function MainContent() {
   );
 
   const workspace = (
-    <div className="space-y-8">
+    <div className="space-y-6 sm:space-y-8">
       <Tabs tabs={tabs} activeValue={activeTab} onTabChange={handleTabChange} />
       <div className="accent-divider mx-auto my-2 h-px w-full opacity-80" aria-hidden="true" />
-      <div className="relative min-h-[520px] rounded-[var(--radius-card)] border border-secondary-500/12 bg-surface-50/94 p-6 shadow-card backdrop-blur-sm sm:backdrop-blur-xl transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_22px_65px_-40px_rgba(15,15,18,0.55)] dark:border-surface-50/12 dark:bg-zinc-900/60">
+      <div className="relative min-h-[520px] rounded-[var(--radius-card)] border border-secondary-500/12 bg-surface-50/94 p-5 shadow-card backdrop-blur-sm transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_22px_65px_-40px_rgba(15,15,18,0.55)] dark:border-surface-50/12 dark:bg-zinc-900/60 sm:p-6 sm:backdrop-blur-xl">
         {activeTab === "resume" && (
           <ResumeUpload
             onParseResume={handleParseResume}
@@ -456,7 +456,7 @@ export default function MainContent() {
         )}
       </div>
       {hasNextTab && (
-        <div className="flex justify-end">
+        <div className="flex justify-center sm:justify-end">
           <SecondaryButton icon={ArrowRight} onClick={handleContinue}>
             Continue
           </SecondaryButton>
@@ -466,10 +466,13 @@ export default function MainContent() {
   );
 
   return (
-    <main data-app-main className="relative z-10 -mt-24 min-h-screen px-4 pb-32 pt-24 sm:px-6 lg:pb-40">
+    <main
+      data-app-main
+      className="relative z-10 -mt-16 min-h-screen px-[var(--page-gutter)] pb-28 pt-20 sm:-mt-20 sm:pb-32 sm:pt-24 lg:-mt-24 lg:pb-40"
+    >
       <ToastContainer>{renderedToasts}</ToastContainer>
       <div className="mx-auto max-w-6xl">
-        <div className="card-glow rounded-[var(--radius-card)] border border-secondary-500/12 bg-surface-50/94 p-8 shadow-card backdrop-blur-sm sm:backdrop-blur-xl transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_24px_70px_-42px_rgba(15,15,18,0.58)] dark:border-surface-50/12 dark:bg-zinc-900/60">
+        <div className="card-glow rounded-[var(--radius-card)] border border-secondary-500/12 bg-surface-50/94 p-6 shadow-card backdrop-blur-sm transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_24px_70px_-42px_rgba(15,15,18,0.58)] dark:border-surface-50/12 dark:bg-zinc-900/60 sm:p-8 sm:backdrop-blur-xl">
           {flowProgress > 0 && (
             <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-smoke-50/70 dark:bg-zinc-900/50">
               <div

--- a/src/components/ui/Tabs.jsx
+++ b/src/components/ui/Tabs.jsx
@@ -61,7 +61,7 @@ export default function Tabs({ tabs, activeValue, onTabChange }) {
     <div
       role="tablist"
       aria-label="Resume workflow navigation"
-      className="relative flex flex-wrap items-center justify-between gap-2 rounded-3xl border border-secondary-500/10 bg-surface-50/70 p-1.5 backdrop-blur-sm dark:border-surface-50/10 dark:bg-zinc-900/60"
+      className="relative flex flex-wrap items-center justify-between gap-2 rounded-[calc(var(--radius-card)*1.2)] border border-secondary-500/10 bg-surface-50/70 p-1.5 backdrop-blur-sm dark:border-surface-50/10 dark:bg-zinc-900/60"
     >
       {tabs.map(({ value, label, icon: Icon }, index) => {
         const isActive = value === activeValue;
@@ -78,7 +78,7 @@ export default function Tabs({ tabs, activeValue, onTabChange }) {
             onClick={() => onTabChange?.(value)}
             onKeyDown={(event) => handleKeyDown(event, index)}
             className={cn(
-              "group tab-pattern-hover relative flex flex-1 items-center justify-center gap-2 overflow-hidden rounded-2xl px-4 py-3 text-sm font-semibold transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:focus-visible:ring-offset-zinc-900",
+              "group tab-pattern-hover relative flex flex-1 items-center justify-center gap-2 overflow-hidden rounded-[calc(var(--radius-card)*0.85)] px-4 py-3 text-sm font-semibold transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:focus-visible:ring-offset-zinc-900",
               isActive
                 ? "bg-surface-50 text-ink-900 shadow-soft dark:bg-zinc-900/70 dark:text-sand-50"
                 : "text-ink-500/80 hover:bg-secondary-500/10 hover:text-ink-700 dark:text-sand-50/60 dark:hover:bg-secondary-500/15"

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -41,7 +41,9 @@ const applyThemeToDocument = (theme) => {
   if (typeof document === "undefined") return;
   const isDark = theme === "dark";
   document.documentElement.classList.toggle("dark", isDark);
-  document.documentElement.dataset.theme = isDark ? "dark" : "light";
+  const nextTheme = isDark ? "dark" : "light";
+  document.documentElement.dataset.theme = nextTheme;
+  document.documentElement.setAttribute("data-theme", nextTheme);
   document.documentElement.style.colorScheme = isDark ? "dark" : "light";
 };
 
@@ -60,6 +62,12 @@ export function useTheme() {
 
   useEffect(() => {
     applyThemeToDocument(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (hasExplicitPreference.current) {
+      persistTheme(theme);
+    }
   }, [theme]);
 
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -5,26 +5,63 @@
 @layer base {
   :root {
     color-scheme: light dark;
+    --page-gradient: linear-gradient(135deg, #0b6b3a 0%, #146356 55%, #0c5335 100%);
+    --page-gradient-dark: linear-gradient(135deg, #0a3f26 0%, #0b3a30 55%, #0c2e25 100%);
+    --page-radial: radial-gradient(circle at 15% -12%, rgba(32, 201, 151, 0.24) 0%, rgba(6, 78, 59, 0) 65%);
+    --page-radial-dark: radial-gradient(circle at 18% -16%, rgba(53, 233, 184, 0.28) 0%, rgba(3, 20, 13, 0) 70%);
+    --page-gutter: 1.25rem;
+    --radius-card: 1.25rem;
+  }
+
+  @media (min-width: 768px) {
+    :root {
+      --page-gutter: 1.75rem;
+      --radius-card: 1.5rem;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    :root {
+      --page-gutter: 2.5rem;
+      --radius-card: 1.75rem;
+    }
   }
 
   html,
   body,
-  #root {
+  #root,
+  #app-root {
     min-height: 100%;
   }
 
   body {
     font-family: var(--font-body);
-    background-color: #0b6b3a;
-    background-image: linear-gradient(135deg, #0b6b3a 0%, #146356 55%, #0c5335 100%);
     color: var(--color-ink-900);
-    transition: background-color var(--duration-breathe) var(--transition-snappy);
+    background-color: #0b6b3a;
+    background: var(--page-gradient);
+    transition: background var(--duration-breathe) var(--transition-snappy);
+    position: relative;
+    overflow-x: hidden;
+    isolation: isolate;
+  }
+
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background: var(--page-radial);
+    z-index: -1;
   }
 
   .dark body {
-    background-color: #0a3f26;
-    background-image: linear-gradient(135deg, #0a3f26 0%, #0b3a30 55%, #0c2e25 100%);
     color: var(--color-sand-50);
+    background-color: #0a3f26;
+    background: var(--page-gradient-dark);
+  }
+
+  .dark body::before {
+    background: var(--page-radial-dark);
   }
 
   h1,

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,4 +1,24 @@
-export const asset = (p: string) =>
-  `${import.meta.env.VITE_ASSETS_BASE_URL?.replace(/\/$/, "")}/${p.replace(/^\//, "")}`;
+const buildVersion =
+  import.meta.env.VITE_BUILD_ID?.toString().trim() ||
+  import.meta.env.VITE_BUILD_TIMESTAMP?.toString().trim() ||
+  "";
 
-export const skyline = () => asset("KAFDH.webp");
+export const withVersion = (url: string) => {
+  if (!buildVersion) return url;
+
+  const [base, hash = ""] = url.split("#");
+  const separator = base.includes("?") ? "&" : "?";
+  const versioned = `${base}${separator}v=${encodeURIComponent(buildVersion)}`;
+  return hash ? `${versioned}#${hash}` : versioned;
+};
+
+export const asset = (p: string) => {
+  const base = import.meta.env.VITE_ASSETS_BASE_URL?.replace(/\/$/, "");
+  const path = p.replace(/^\//, "");
+  if (!base) {
+    return `/${path}`;
+  }
+  return `${base}/${path}`;
+};
+
+export const skyline = () => withVersion(asset("KAFDH.webp"));


### PR DESCRIPTION
## Context
- unify the resume optimizer background treatment behind a single root gradient so the hero and workspace flow together across breakpoints
- persist theme selection on the `<html>` element and add cache-busting to the skyline hero asset so CDN swaps take effect immediately

## Changes
- add a `withVersion` helper in the asset library and apply it to the skyline URL to append the build identifier when present
- move the green gradient into global CSS with responsive spacing variables, remove the hero-only backdrop, and tune header/main paddings and radii for 390/768/1280 widths
- update the theme hook to sync `<html data-theme>` and localStorage, and align the tab controls/card shells with the breakpoint radius scale

## Risk
- Medium: shared layout styles and theme handling were updated.

## Screenshots
- N/A (CLI environment)

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d434bf6bec83308712be6a18a9e642