### PR TITLE
Normalize OpenAI proxy defaults and debug output

### DIFF
--- a/netlify/functions/ai.ts
+++ b/netlify/functions/ai.ts
@@ -18,13 +18,117 @@ const sanitize = (value: unknown): string => {
   return value.trim();
 };
 
-const buildMessages = (body: any) => {
-  if (Array.isArray(body?.messages) && body.messages.length > 0) {
-    return body.messages;
+type ResponseContentItem = { type: string; [key: string]: unknown };
+type ResponseMessage = { role: string; content: ResponseContentItem[] };
+
+const toInputText = (text: string): ResponseContentItem => ({
+  type: "input_text",
+  text,
+});
+
+const normalizeContentItem = (item: unknown): ResponseContentItem | null => {
+  if (typeof item === "string") {
+    const text = sanitize(item);
+    return text ? toInputText(text) : null;
   }
 
-  if (Array.isArray(body?.input) && body.input.length > 0) {
-    return body.input;
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const candidate = item as Record<string, unknown>;
+  if (typeof candidate.text === "string") {
+    const text = candidate.text.trim();
+    if (!text) return null;
+    const rawType = typeof candidate.type === "string" ? candidate.type.trim() : "";
+    const type = rawType === "text" || rawType.length === 0 ? "input_text" : rawType;
+    return { ...candidate, type, text } as ResponseContentItem;
+  }
+
+  return candidate as ResponseContentItem;
+};
+
+const normalizeContent = (content: unknown): ResponseContentItem[] | null => {
+  if (Array.isArray(content)) {
+    const normalized = content
+      .map((item) => normalizeContentItem(item))
+      .filter((item): item is ResponseContentItem => Boolean(item));
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  if (typeof content === "string") {
+    const text = sanitize(content);
+    return text ? [toInputText(text)] : null;
+  }
+
+  if (content && typeof content === "object") {
+    const candidate = content as Record<string, unknown>;
+    if (typeof candidate.text === "string") {
+      const text = candidate.text.trim();
+      if (!text) return null;
+      const rawType = typeof candidate.type === "string" ? candidate.type.trim() : "";
+      const type = rawType === "text" || rawType.length === 0 ? "input_text" : rawType;
+      return [{ type, text }];
+    }
+  }
+
+  return null;
+};
+
+const normalizeMessage = (value: unknown): ResponseMessage | null => {
+  if (typeof value === "string") {
+    const text = sanitize(value);
+    return text ? { role: "user", content: [toInputText(text)] } : null;
+  }
+
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const role = typeof candidate.role === "string" ? candidate.role.trim() : "user";
+  const content = normalizeContent(candidate.content ?? candidate.text ?? null);
+
+  if (!content) {
+    return null;
+  }
+
+  return { role: role || "user", content };
+};
+
+const createUserMessage = (text: string): ResponseMessage => ({
+  role: "user",
+  content: [toInputText(text)],
+});
+
+const normalizeInput = (value: unknown): ResponseMessage[] | null => {
+  if (!value) return null;
+
+  if (Array.isArray(value)) {
+    const normalized = value
+      .map((item) => normalizeMessage(item))
+      .filter((item): item is ResponseMessage => Boolean(item));
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  const single = normalizeMessage(value);
+  return single ? [single] : null;
+};
+
+const buildMessages = (body: any): ResponseMessage[] | null => {
+  const fromMessages = normalizeInput(body?.messages);
+  if (fromMessages) {
+    return fromMessages;
+  }
+
+  const fromInput = normalizeInput(body?.input);
+  if (fromInput) {
+    return fromInput;
+  }
+
+  const prompt = sanitize(body?.prompt);
+  if (prompt) {
+    return [createUserMessage(prompt)];
   }
 
   const resume = sanitize(body?.resumeText ?? body?.resume);
@@ -41,61 +145,22 @@ const buildMessages = (body: any) => {
     }
 
     const compiled = segments.join("\n\n");
-    const messages: any[] = [];
+    const messages: ResponseMessage[] = [];
 
     if (systemPrompt) {
       messages.push({
         role: "system",
-        content: [
-          {
-            type: "text",
-            text: systemPrompt,
-          },
-        ],
+        content: [toInputText(systemPrompt)],
       });
     }
 
-    messages.push({
-      role: "user",
-      content: [
-        {
-          type: "text",
-          text: compiled,
-        },
-      ],
-    });
-
+    messages.push(createUserMessage(compiled));
     return messages;
-  }
-
-  const prompt = sanitize(body?.prompt);
-  if (prompt) {
-    return [
-      {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: prompt,
-          },
-        ],
-      },
-    ];
   }
 
   const text = sanitize(body?.text);
   if (text) {
-    return [
-      {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: text,
-          },
-        ],
-      },
-    ];
+    return [createUserMessage(text)];
   }
 
   return null;
@@ -152,14 +217,19 @@ const handler: Handler = async (event) => {
     const messages = buildMessages(body);
 
     const hasMessages = Array.isArray(body?.messages) && body.messages.length > 0;
-    const hasInput = Array.isArray(body?.input) && body.input.length > 0;
+    const hasInputArray = Array.isArray(body?.input) && body.input.length > 0;
+    const hasInputScalar = typeof body?.input === "string" && sanitize(body.input).length > 0;
+    const hasInputObject =
+      body?.input && typeof body.input === "object" && !Array.isArray(body.input) ? Object.keys(body.input).length > 0 : false;
+    const hasPrompt = typeof body?.prompt === "string" && sanitize(body.prompt).length > 0;
+    const hasText = typeof body?.text === "string" && sanitize(body.text).length > 0;
 
-    if (!resume && !job && !hasMessages && !hasInput) {
+    if (!resume && !job && !hasMessages && !hasInputArray && !hasInputScalar && !hasInputObject && !hasPrompt && !hasText) {
       return {
         statusCode: 400,
         headers: HEADERS,
         body: JSON.stringify({
-          error: "Request must include resumeText, jobText, or messages.",
+          error: "Request must include resumeText, jobText, messages, input, or prompt.",
         }),
       };
     }
@@ -227,6 +297,7 @@ const handler: Handler = async (event) => {
     console.info("[ai] request complete", {
       requestId,
       model: options.model,
+      temperature: options.temperature,
       max_output_tokens: options.max_output_tokens ?? null,
       latency_ms: latency,
     });
@@ -235,7 +306,6 @@ const handler: Handler = async (event) => {
       statusCode: 200,
       headers: HEADERS,
       body: JSON.stringify({
-        id: data?.id ?? null,
         model: data?.model ?? options.model,
         usage: data?.usage ?? null,
         output_text: outputText,

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowRight, FileText, Sparkles, Target, UserPlus, LogIn } from "lucide-react";
-import { parseResume, analyzeResume, optimizeResume } from "../services/api.js";
+import {
+  parseResume,
+  analyzeResume,
+  optimizeResume,
+  AI_DEFAULT_TEMPERATURE,
+} from "../services/api.js";
 import { useAuth } from "../hooks/useAuth.jsx";
 import ResumeUpload from "../features/ResumeUpload.jsx";
 import JobMatch from "./Features/JobMatch.jsx";
@@ -18,14 +23,13 @@ const tabs = [
   { value: "optimize", label: "Optimize", icon: Sparkles },
 ];
 
-const API_TEMPERATURE = 1;
 const TOAST_IDS = {
   upload: "toast:upload",
   match: "toast:match",
   optimize: "toast:optimize",
 };
 const TAB_STORAGE_KEY = "airo:lastActiveTab";
-const withTemperature = (message) => `${message} • Temp ${API_TEMPERATURE}`;
+const withTemperature = (message) => `${message} • Temp ${AI_DEFAULT_TEMPERATURE}`;
 
 const getId = () => {
   if (typeof crypto !== "undefined" && crypto.randomUUID) {
@@ -509,7 +513,7 @@ export default function MainContent() {
           <section className="mt-6 text-xs text-ink-500 dark:text-surface-50/70">
             <div className="rounded-[var(--radius-card)] border border-secondary-500/20 bg-surface-50/90 p-4 shadow-soft backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/15 dark:bg-zinc-900/60">
               <p className="font-semibold uppercase tracking-[0.24em] text-secondary-500">AI Debug</p>
-              <dl className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-6">
+              <dl className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-7">
                 <div>
                   <dt className="text-[10px] uppercase tracking-[0.24em] text-ink-500/70 dark:text-surface-50/60">Status</dt>
                   <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">{aiDebug.status}</dd>
@@ -519,8 +523,23 @@ export default function MainContent() {
                   <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">{aiDebug.model ?? "–"}</dd>
                 </div>
                 <div>
+                  <dt className="text-[10px] uppercase tracking-[0.24em] text-ink-500/70 dark:text-surface-50/60">
+                    Temperature
+                  </dt>
+                  <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">
+                    {typeof aiDebug.temperature === "number"
+                      ? Number.isInteger(aiDebug.temperature)
+                        ? aiDebug.temperature
+                        : aiDebug.temperature.toFixed(2)
+                      : aiDebug.temperature ?? "–"}
+                  </dd>
+                </div>
+                <div>
                   <dt className="text-[10px] uppercase tracking-[0.24em] text-ink-500/70 dark:text-surface-50/60">Tokens</dt>
-                  <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">{aiDebug.tokens ?? "–"}</dd>
+                  <dd className="mt-1 font-medium text-ink-700 dark:text-surface-50">
+                    {aiDebug.tokens ?? "–"}
+                    {aiDebug.maxOutputTokens ? ` / ${aiDebug.maxOutputTokens}` : ""}
+                  </dd>
                 </div>
                 <div>
                   <dt className="text-[10px] uppercase tracking-[0.24em] text-ink-500/70 dark:text-surface-50/60">Latency</dt>

--- a/src/lib/aiClient.test.ts
+++ b/src/lib/aiClient.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { runOptimization } from "./aiClient";
+
+describe("runOptimization", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // @ts-expect-error - cleanup for environments without fetch
+      delete global.fetch;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("wraps abort errors with a friendly message", async () => {
+    const abortDomError = new DOMException("The operation was aborted.", "AbortError");
+    global.fetch = vi.fn().mockRejectedValueOnce(abortDomError) as unknown as typeof fetch;
+
+    const onError = vi.fn();
+
+    await expect(runOptimization({}, { onError })).rejects.toThrow("AI request timed out");
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [error] = onError.mock.calls[0];
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe("AI request timed out");
+    expect(error.name).toBe("AbortError");
+  });
+});

--- a/src/lib/aiClient.ts
+++ b/src/lib/aiClient.ts
@@ -7,6 +7,8 @@ export type RunOptimizationDebug = {
   status: "success" | "error";
   model?: string | null;
   tokens?: number | null;
+  temperature?: number | null;
+  maxOutputTokens?: number | null;
   latencyMs?: number;
   requestId?: string | null;
   statusCode?: number | null;
@@ -39,6 +41,9 @@ export class AiRequestError extends Error {
 }
 
 const canUseMock = () => import.meta.env.MODE === "development" && USE_MOCK;
+
+const toNumber = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null;
 
 const parseError = (payload: any): { message: string; code: string | null } => {
   if (!payload || typeof payload !== "object") {
@@ -87,6 +92,11 @@ export async function runOptimization(
 
     const data = await response.json().catch(() => ({}));
     const latencyMs = now() - started;
+    const requestedTemperature = toNumber(payload?.temperature) ?? 1;
+    const requestedMaxTokens =
+      toNumber(payload?.max_output_tokens) ?? toNumber(payload?.max_completion_tokens);
+    const responseRequestId =
+      typeof response.headers?.get === "function" ? response.headers.get("x-nf-request-id") : null;
 
     if (!response.ok) {
       const { message, code } = parseError(data);
@@ -97,6 +107,9 @@ export async function runOptimization(
         latencyMs,
         statusCode: response.status,
         errorCode: code ?? null,
+        temperature: requestedTemperature,
+        maxOutputTokens: requestedMaxTokens ?? null,
+        requestId: responseRequestId,
       });
       options.onError?.(error);
       throw error;
@@ -115,9 +128,11 @@ export async function runOptimization(
       model: typeof data?.model === "string" ? data.model : (payload?.model as string | undefined) ?? null,
       tokens: tokens ?? null,
       latencyMs,
-      requestId: typeof data?.id === "string" ? data.id : null,
+      requestId: responseRequestId ?? (typeof data?.id === "string" ? data.id : null),
       statusCode: 200,
       errorCode: null,
+      temperature: requestedTemperature,
+      maxOutputTokens: requestedMaxTokens ?? null,
     });
 
     return { text, raw: data };
@@ -129,6 +144,15 @@ export async function runOptimization(
         : new Error(typeof error === "string" ? error : "Unable to reach AI service");
     const statusCode = error instanceof AiRequestError ? error.status : null;
     const errorCode = error instanceof AiRequestError ? error.code : null;
+    const finalError = (() => {
+      if (normalized.name === "AbortError") {
+        const abortError = new Error("AI request timed out");
+        abortError.name = normalized.name;
+        return abortError;
+      }
+
+      return normalized;
+    })();
 
     options.onDebug?.({
       status: "error",
@@ -136,17 +160,17 @@ export async function runOptimization(
       latencyMs,
       statusCode,
       errorCode,
+      temperature: toNumber(payload?.temperature) ?? 1,
+      maxOutputTokens:
+        toNumber(payload?.max_output_tokens) ?? toNumber(payload?.max_completion_tokens) ?? null,
     });
-    if (normalized.name === "AbortError") {
-      normalized.message = "AI request timed out";
-    }
-    options.onError?.(normalized);
+    options.onError?.(finalError);
 
     if (canUseMock()) {
       return { text: "", raw: null };
     }
 
-    throw normalized;
+    throw finalError;
   } finally {
     signal?.removeEventListener?.("abort", abortHandler);
   }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -2,6 +2,8 @@
 
 import { runOptimization, USE_MOCK } from "../lib/aiClient";
 
+export const AI_DEFAULT_TEMPERATURE = 1;
+
 const FUNCTION_BASE_PATH = "/.netlify/functions";
 const MATCH_ENDPOINT = `${FUNCTION_BASE_PATH}/match-score`;
 const REQUEST_TIMEOUT = 15000;
@@ -295,6 +297,7 @@ export const optimizeResume = async (
       jobText: job.slice(0, 4000),
       mode,
       preview,
+      temperature: AI_DEFAULT_TEMPERATURE,
       messages: buildMessages(resume, job, mode),
     };
 

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -9,7 +9,7 @@ vi.mock('../lib/aiClient', () => {
 });
 
 import { runOptimization } from '../lib/aiClient';
-import { analyzeResume, optimizeResume, parseResume } from './api.js';
+import { analyzeResume, optimizeResume, parseResume, AI_DEFAULT_TEMPERATURE } from './api.js';
 
 beforeEach(() => {
   global.fetch = vi.fn();
@@ -103,6 +103,7 @@ describe('optimizeResume', () => {
         jobText: 'job',
         mode: 'auto',
         messages: expect.any(Array),
+        temperature: AI_DEFAULT_TEMPERATURE,
       }),
       expect.objectContaining({ signal: expect.any(Object) })
     );
@@ -110,6 +111,7 @@ describe('optimizeResume', () => {
     const payload = runOptimization.mock.calls[0][0];
     expect(payload.messages[0]).toMatchObject({ role: 'system' });
     expect(payload.messages[1]).toMatchObject({ role: 'user' });
+    expect(payload.temperature).toBe(AI_DEFAULT_TEMPERATURE);
     expect(result.cards).toHaveLength(1);
     expect(result.keywords.add).toContain('react');
     expect(result.source).toBe('openai');


### PR DESCRIPTION
## Context
- Normalize the Requests hitting the OpenAI Responses API to stop 400s caused by legacy payloads.
- Surface default settings in the client so devs can verify model, temperature, and tokens in one place.

## Changes
- Normalize any `messages`, `input`, or `prompt` payloads to Responses-compatible `input_text` content and map token aliases with safe defaults in the Netlify AI proxy.
- Default requests to `gpt-5-nano` at temperature 1, translate max token aliases, and tighten logging/response shape for the proxy.
- Ensure resume optimizations always send the centralized temperature, enrich client debug callbacks with temperature/max token metadata, and expose the data in the dev-only debug panel.
- Guard against DOM `AbortError` instances so we return a friendly timeout error without mutating read-only properties, and cover the regression with a unit test.

## Risk
- **Medium:** touches the primary AI proxy and client adapter; regressions would impact resume optimizations. Covered by unit tests and manual verification steps.

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43a2dbd34833092e313d08ca7a633