### PR TITLE
Fix skyline asset resolution and favicon

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,6 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a0a16515be92a303c8882e5b00c5a32f25b98926c35406a5820575df4f4f48d
-size 142
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+  Content-Type: application/javascript

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,3 +1,26 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30c2bdd04b647a6dec5545c584b21771e2665cbe96f08096ba5c51e638d8f4a2
-size 1405006
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-labelledby="airoIconTitle">
+  <title id="airoIconTitle">AI Resume Optimizer icon</title>
+  <defs>
+    <linearGradient id="airoGradient" x1="12%" x2="88%" y1="8%" y2="92%">
+      <stop offset="0%" stop-color="#2FE1AA" />
+      <stop offset="48%" stop-color="#14B07A" />
+      <stop offset="100%" stop-color="#0A6037" />
+    </linearGradient>
+    <filter id="airoGlow" x="-20%" y="-20%" width="140%" height="140%" filterUnits="objectBoundingBox">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="1.2" result="blur" />
+    </filter>
+  </defs>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="32" cy="32" r="28" fill="url(#airoGradient)" stroke="rgba(255,255,255,0.14)" stroke-width="2" />
+    <path
+      d="M32 16l3.9 9.6 10.4.8-7.9 6.7 2.5 10.2L32 37.4l-8.9 5.9 2.5-10.2-7.9-6.7 10.4-.8L32 16z"
+      fill="rgba(255,255,255,0.92)"
+      filter="url(#airoGlow)"
+    />
+    <path
+      d="M32 17.4l3.3 8.1 8.7.7-6.6 5.6 2 8.6L32 36.2l-7.4 5.3 2-8.6-6.6-5.6 8.7-.7 3.3-8.1z"
+      fill="#0B3521"
+      opacity="0.25"
+    />
+  </g>
+</svg>

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -33,7 +33,14 @@ describe("asset", () => {
   it("normalizes the configured asset base", async () => {
     vi.stubEnv("VITE_ASSETS_BASE_URL", "https://cdn.example.com/media/");
     const { asset } = await loadModule();
-    expect(asset("/KAFDHD.webp")).toBe("https://cdn.example.com/media/KAFDHD.webp");
+    expect(asset("/KAFDH.webp")).toBe("https://cdn.example.com/media/KAFDH.webp");
+  });
+
+  it("returns absolute urls unchanged", async () => {
+    const { asset } = await loadModule();
+    expect(asset("https://storage.supabase.co/object/public/hero.webp")).toBe(
+      "https://storage.supabase.co/object/public/hero.webp",
+    );
   });
 });
 
@@ -48,5 +55,11 @@ describe("skyline", () => {
     vi.stubEnv("VITE_BUILD_ID", "20240924");
     const { skyline } = await loadModule();
     expect(skyline()).toBe("https://cdn.example.com/media/KAFDH.webp?v=20240924");
+  });
+
+  it("prefers the configured skyline asset when provided", async () => {
+    vi.stubEnv("VITE_SKYLINE_ASSET", "hero/custom.webp");
+    const { skyline } = await loadModule();
+    expect(skyline()).toBe("/hero/custom.webp");
   });
 });

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,5 +1,6 @@
 const ABSOLUTE_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
 const BUILD_VERSION_KEYS = ["VITE_BUILD_ID", "VITE_BUILD_TIMESTAMP"] as const;
+const SKYLINE_ASSET_KEY = "VITE_SKYLINE_ASSET" as const;
 
 const readBuildVersion = () => {
   const env = import.meta.env as Record<string, string | undefined> | undefined;
@@ -58,11 +59,29 @@ const resolveAssetBase = () => {
 const ASSET_BASE = resolveAssetBase();
 
 export const asset = (p: string) => {
-  const normalizedPath = (p ?? "").replace(/^\//, "");
+  const raw = typeof p === "string" ? p.trim() : "";
+  if (!raw) {
+    return raw;
+  }
+
+  if (ABSOLUTE_URL_PATTERN.test(raw)) {
+    return raw;
+  }
+
+  const normalizedPath = raw.replace(/^\/+/, "");
   if (!ASSET_BASE) {
     return `/${normalizedPath}`;
   }
   return `${ASSET_BASE}/${normalizedPath}`;
 };
 
-export const skyline = () => withVersion(asset("KAFDH.webp"));
+const resolveSkylineAsset = () => {
+  const env = import.meta.env as Record<string, string | undefined> | undefined;
+  const configured = env?.[SKYLINE_ASSET_KEY];
+  if (typeof configured === "string" && configured.trim().length > 0) {
+    return configured.trim();
+  }
+  return "KAFDH.webp";
+};
+
+export const skyline = () => withVersion(asset(resolveSkylineAsset()));


### PR DESCRIPTION
## Summary
- replace the Git LFS pointer in `public/_headers` with an actual Netlify headers file so HTML stays uncached while hashed assets remain immutable
- ensure new deploys serve the latest stylesheet instead of a stale filename so the Supabase-hosted hero loads consistently

## Testing
- npm ci *(fails: npm registry returns 403 in this environment)*
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4714a1e1083308f71a5abd1f72618