### PR TITLE
Fix hero skyline asset resolution

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -22,6 +22,16 @@ export default function Header() {
   const { user, signInWithGoogle, signOut } = useAuth();
   const { theme, isDark, setTheme } = useTheme();
   const skylineUrl = useMemo(() => skyline(), []);
+  const heroBackgroundStyle = useMemo(() => {
+    if (typeof skylineUrl !== "string" || skylineUrl.length === 0) {
+      return undefined;
+    }
+    return {
+      backgroundImage: `url('${skylineUrl}')`,
+      backgroundSize: "cover",
+      backgroundPosition: "center",
+    };
+  }, [skylineUrl]);
   const [animateSkyline, setAnimateSkyline] = useState(false);
 
   useEffect(() => {
@@ -67,7 +77,10 @@ export default function Header() {
   );
 
   return (
-    <header className="hero-bg-animate relative isolate flex min-h-screen min-h-[100svh] flex-col justify-between gap-12 overflow-hidden text-surface-50 pb-16 pt-10 sm:pb-24 sm:pt-16 md:min-h-[100dvh]">
+    <header
+      className="hero-bg-animate relative isolate flex min-h-screen min-h-[100svh] flex-col justify-between gap-12 overflow-hidden bg-cover bg-center text-surface-50 pb-16 pt-10 sm:pb-24 sm:pt-16 md:min-h-[100dvh]"
+      style={heroBackgroundStyle}
+    >
       {typeof skylineUrl === "string" && skylineUrl ? (
         <div
           aria-hidden="true"

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -54,7 +54,7 @@ describe("skyline", () => {
     vi.stubEnv("VITE_ASSETS_BASE_URL", "https://cdn.example.com/media");
     vi.stubEnv("VITE_BUILD_ID", "20240924");
     const { skyline } = await loadModule();
-    expect(skyline()).toBe("https://cdn.example.com/media/KAFDH.webp?v=20240924");
+    expect(skyline()).toBe("https://cdn.example.com/media/hero/KAFDH.webp?v=20240924");
   });
 
   it("prefers the configured skyline asset when provided", async () => {
@@ -73,9 +73,16 @@ describe("skyline", () => {
     );
   });
 
-  it("falls back to the default asset when the bucket is missing", async () => {
+  it("uses the default marketing asset when bucket metadata is omitted", async () => {
     vi.stubEnv("VITE_SUPABASE_URL", "https://project.supabase.co");
     const { skyline } = await loadModule();
-    expect(skyline()).toBe("/KAFDH.webp");
+    expect(skyline()).toBe(
+      "https://project.supabase.co/storage/v1/object/public/marketing/hero/KAFDH.webp",
+    );
+  });
+
+  it("returns the default object path when Supabase is not configured", async () => {
+    const { skyline } = await loadModule();
+    expect(skyline()).toBe("/hero/KAFDH.webp");
   });
 });

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -5,6 +5,12 @@ const SUPABASE_URL_KEY = "VITE_SUPABASE_URL" as const;
 const SKYLINE_BUCKET_KEY = "VITE_SUPABASE_SKYLINE_BUCKET" as const;
 const SKYLINE_OBJECT_KEY = "VITE_SUPABASE_SKYLINE_OBJECT" as const;
 
+const DEFAULT_SKYLINE_BUCKET = "marketing" as const;
+const DEFAULT_SKYLINE_OBJECT = "hero/KAFDH.webp" as const;
+
+export const HERO_SUPABASE_BUCKET = DEFAULT_SKYLINE_BUCKET;
+export const HERO_SUPABASE_OBJECT = DEFAULT_SKYLINE_OBJECT;
+
 const readBuildVersion = () => {
   const env = import.meta.env as Record<string, string | undefined> | undefined;
   for (const key of BUILD_VERSION_KEYS) {
@@ -97,17 +103,25 @@ const resolveSkylineAsset = () => {
     return configured.trim();
   }
   const supabaseUrl = env?.[SUPABASE_URL_KEY];
-  const bucket = env?.[SKYLINE_BUCKET_KEY];
-  const objectKey = env?.[SKYLINE_OBJECT_KEY] || "KAFDH.webp";
+  const bucketRaw = env?.[SKYLINE_BUCKET_KEY];
+  const objectKeyRaw = env?.[SKYLINE_OBJECT_KEY];
+  const bucket =
+    typeof bucketRaw === "string" && bucketRaw.trim().length > 0
+      ? bucketRaw
+      : DEFAULT_SKYLINE_BUCKET;
+  const objectKey =
+    typeof objectKeyRaw === "string" && objectKeyRaw.trim().length > 0
+      ? objectKeyRaw
+      : DEFAULT_SKYLINE_OBJECT;
 
-  if (typeof supabaseUrl === "string" && supabaseUrl.trim().length > 0 && typeof objectKey === "string") {
+  if (typeof supabaseUrl === "string" && supabaseUrl.trim().length > 0) {
     const publicUrl = buildSupabasePublicUrl(supabaseUrl, bucket ?? "", objectKey);
     if (publicUrl) {
       return publicUrl;
     }
   }
 
-  return "KAFDH.webp";
+  return objectKey;
 };
 
 export const skyline = () => withVersion(asset(resolveSkylineAsset()));


### PR DESCRIPTION
## Summary
- ensure the hero skyline always resolves to the Supabase marketing asset with sensible defaults
- add a direct background style fallback on the header so Tailwind utilities like bg-cover/bg-center apply even if the custom class fails
- extend asset unit tests to cover the default Supabase marketing asset cases

## Testing
- npm run lint
- npm run test

## Build check
```
npm run build
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
> resume-customizer@0.0.0 build
> node scripts/build.mjs
vite v7.1.6 building for production...
✓ 1770 modules transformed.
dist/index.html                   2.07 kB │ gzip:   0.79 kB
dist/assets/index-_YalFzcQ.css   75.64 kB │ gzip:  11.98 kB
dist/assets/index-BuKzOJFB.js   425.81 kB │ gzip: 127.14 kB
✓ built in 5.07s
```

![Styled hero light mode](browser:/invocations/gnydpjyg/artifacts/artifacts/hero-light.png)


------
https://chatgpt.com/codex/tasks/task_e_68d488eeafe88330a2953ed64faa734b