### PR TITLE
ATS export + unified parsing + robust match score UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Make your resume match the job—fast. Compare a resume to a job description and
 - Upload a resume (PDF/DOCX or paste text)
 - Paste a job description
 - Get a match score, missing keywords, and clear rewrite suggestions
+- Export styled or ATS-plain PDF versions of your resume
 
 > ⚠️ **Privacy:** Resumes are stored in Supabase Storage (`resumes/`) for processing. No keys are exposed client-side. You can delete your file from your account at any time.
 

--- a/netlify/functions/match-score.ts
+++ b/netlify/functions/match-score.ts
@@ -340,12 +340,10 @@ const handler: Handler = async (event) => {
       headers: HEADERS,
       body: JSON.stringify({
         score,
-        explanations: {
-          topMissing: missing.slice(0, 12),
-          topHits: hits.slice(0, 12),
-          cosine,
-          coverage: Number(coverage.toFixed(4)),
-        },
+        coverage: Number(coverage.toFixed(4)),
+        similarity: cosine,
+        missing_keywords: missing.slice(0, 12),
+        matched_keywords: hits.slice(0, 12),
       }),
     };
   } catch (error) {

--- a/netlify/functions/parse-resume.ts
+++ b/netlify/functions/parse-resume.ts
@@ -1,0 +1,276 @@
+import type { Handler } from "@netlify/functions";
+import { inflateRawSync } from "node:zlib";
+import { buildResumeDocument } from "../../shared/normalize-resume.js";
+
+const HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Content-Type": "application/json",
+} as const;
+
+type ParseResumeRequest =
+  | {
+      kind: "text";
+      value?: string;
+    }
+  | {
+      kind: "file";
+      name?: string;
+      mime?: string;
+      data?: string;
+    };
+
+const MAX_BYTES = 8 * 1024 * 1024; // 8 MB safety guard
+
+const decodeBase64 = (value: string): Buffer => {
+  try {
+    return Buffer.from(value, "base64");
+  } catch {
+    throw new Error("Invalid file encoding.");
+  }
+};
+
+const decodePdfEscapes = (value: string): string =>
+  value
+    .replace(/\\([nrtbf\\()])/g, (_, char: string) => {
+      switch (char) {
+        case "n":
+          return "\n";
+        case "r":
+          return "\r";
+        case "t":
+          return "\t";
+        case "b":
+          return "\b";
+        case "f":
+          return "\f";
+        case "(":
+          return "(";
+        case ")":
+          return ")";
+        case "\\":
+          return "\\";
+        default:
+          return char;
+      }
+    })
+    .replace(/\\([0-7]{1,3})/g, (_, octal: string) => String.fromCharCode(parseInt(octal, 8)));
+
+const decodeHexString = (hex: string): string => {
+  const clean = hex.replace(/\s+/g, "");
+  if (clean.length % 2 === 1) {
+    return Buffer.from(`${clean}0`, "hex").toString("utf8");
+  }
+  return Buffer.from(clean, "hex").toString("utf8");
+};
+
+const extractPdfText = async (buffer: Buffer): Promise<string> => {
+  const content = buffer.toString("latin1");
+  const blocks = Array.from(content.matchAll(/BT[\s\S]*?ET/g));
+  const lines: string[] = [];
+
+  for (const block of blocks) {
+    const segment = block[0];
+    const textChunks: string[] = [];
+    const stringMatches = segment.matchAll(/\((?:\\.|[^\\)])*\)/g);
+    for (const match of stringMatches) {
+      const inner = match[0].slice(1, -1);
+      textChunks.push(decodePdfEscapes(inner));
+    }
+    const hexMatches = segment.matchAll(/<([0-9A-Fa-f\s]+)>/g);
+    for (const match of hexMatches) {
+      textChunks.push(decodeHexString(match[1]));
+    }
+    const line = textChunks
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+    if (line) {
+      lines.push(line);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+const decodeEntities = (value: string): string =>
+  value
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+
+const findDocumentXml = (buffer: Buffer): string | null => {
+  const signature = Buffer.from([0x50, 0x4b, 0x05, 0x06]);
+  for (let i = buffer.length - signature.length; i >= 0; i--) {
+    if (buffer.slice(i, i + 4).equals(signature)) {
+      const centralDirOffset = buffer.readUInt32LE(i + 16);
+      const totalEntries = buffer.readUInt16LE(i + 10);
+      let offset = centralDirOffset;
+      for (let entry = 0; entry < totalEntries; entry++) {
+        const headerSig = buffer.readUInt32LE(offset);
+        if (headerSig !== 0x02014b50) {
+          break;
+        }
+        const compression = buffer.readUInt16LE(offset + 10);
+        const compressedSize = buffer.readUInt32LE(offset + 20);
+        const nameLength = buffer.readUInt16LE(offset + 28);
+        const extraLength = buffer.readUInt16LE(offset + 30);
+        const commentLength = buffer.readUInt16LE(offset + 32);
+        const fileName = buffer
+          .slice(offset + 46, offset + 46 + nameLength)
+          .toString("utf8");
+        const localHeaderOffset = buffer.readUInt32LE(offset + 42);
+
+        if (fileName === "word/document.xml") {
+          const localSig = buffer.readUInt32LE(localHeaderOffset);
+          if (localSig !== 0x04034b50) {
+            return null;
+          }
+          const localNameLen = buffer.readUInt16LE(localHeaderOffset + 26);
+          const localExtraLen = buffer.readUInt16LE(localHeaderOffset + 28);
+          const dataStart = localHeaderOffset + 30 + localNameLen + localExtraLen;
+          const compressed = buffer.slice(dataStart, dataStart + compressedSize);
+          if (compression === 0) {
+            return compressed.toString("utf8");
+          }
+          if (compression === 8) {
+            return inflateRawSync(compressed).toString("utf8");
+          }
+          throw new Error("Unsupported DOCX compression method");
+        }
+
+        offset += 46 + nameLength + extraLength + commentLength;
+      }
+      break;
+    }
+  }
+  return null;
+};
+
+const extractDocxText = async (buffer: Buffer): Promise<string> => {
+  const xml = findDocumentXml(buffer);
+  if (!xml) {
+    return "";
+  }
+  const paragraphs = Array.from(xml.matchAll(/<w:p[\s\S]*?<\/w:p>/gi));
+  const lines = paragraphs
+    .map((match) => match[0])
+    .map((paragraph) => {
+      const hasBullet = /w:numPr/.test(paragraph) || /ListParagraph/i.test(paragraph);
+      const text = decodeEntities(
+        paragraph
+          .replace(/<w:tab[^>]*\/>/gi, " \t ")
+          .replace(/<w:br[^>]*\/>/gi, "\n")
+          .replace(/<[^>]+>/g, " ")
+      )
+        .replace(/\s+/g, " ")
+        .trim();
+      if (!text) return null;
+      return hasBullet ? `• ${text}` : text;
+    })
+    .filter((line): line is string => Boolean(line));
+
+  if (lines.length === 0) {
+    return decodeEntities(
+      xml
+        .replace(/<w:p[^>]*>/gi, "\n")
+        .replace(/<[^>]+>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim(),
+    );
+  }
+
+  return lines.join("\n");
+};
+
+const inferType = (payload: { mime?: string; name?: string }): string => {
+  const { mime, name } = payload;
+  if (mime) return mime;
+  if (!name) return "";
+  const lowered = name.toLowerCase();
+  if (lowered.endsWith(".pdf")) return "application/pdf";
+  if (lowered.endsWith(".docx")) {
+    return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+  }
+  return "";
+};
+
+const extractText = async (body: ParseResumeRequest): Promise<string> => {
+  if (body.kind === "text") {
+    return typeof body.value === "string" ? body.value : "";
+  }
+
+  if (body.kind === "file") {
+    if (!body.data) {
+      throw new Error("File payload missing content.");
+    }
+    const buffer = decodeBase64(body.data);
+    if (!buffer.byteLength) {
+      throw new Error("File payload was empty.");
+    }
+    if (buffer.byteLength > MAX_BYTES) {
+      throw new Error("File exceeds the maximum supported size (8 MB).");
+    }
+    const type = inferType(body);
+    switch (type) {
+      case "application/pdf":
+        return extractPdfText(buffer);
+      case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+        return extractDocxText(buffer);
+      default:
+        throw new Error("Unsupported file type. Upload PDF or DOCX.");
+    }
+  }
+
+  throw new Error("Invalid parse request.");
+};
+
+const handler: Handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 200,
+      headers: HEADERS,
+      body: "",
+    };
+  }
+
+  if (event.httpMethod !== "POST") {
+    return {
+      statusCode: 405,
+      headers: HEADERS,
+      body: JSON.stringify({ error: "Method not allowed" }),
+    };
+  }
+
+  try {
+    const body: ParseResumeRequest = event.body ? JSON.parse(event.body) : { kind: "text", value: "" };
+    const text = await extractText(body);
+    const normalized = buildResumeDocument(text);
+
+    if (!normalized.plainText || normalized.plainText.trim().length === 0) {
+      return {
+        statusCode: 400,
+        headers: HEADERS,
+        body: JSON.stringify({ error: "Unable to extract readable text from the resume." }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers: HEADERS,
+      body: JSON.stringify({ document: normalized }),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to parse resume.";
+    return {
+      statusCode: 400,
+      headers: HEADERS,
+      body: JSON.stringify({ error: message }),
+    };
+  }
+};
+
+export { handler };

--- a/shared/normalize-resume.js
+++ b/shared/normalize-resume.js
@@ -1,0 +1,148 @@
+const SECTION_KEYWORDS = {
+  contact: ["contact", "contact information", "personal details"],
+  summary: ["summary", "professional summary", "profile", "objective", "about"],
+  skills: ["skills", "technical skills", "core skills", "competencies", "expertise"],
+  experience: [
+    "experience",
+    "work experience",
+    "professional experience",
+    "employment history",
+    "career history",
+    "work history",
+  ],
+  education: ["education", "academic history", "academics", "training"],
+  projects: ["projects", "selected projects", "key projects", "portfolio"],
+  certifications: ["certifications", "certificates", "licenses", "accreditations"],
+};
+
+const ORDERED_SECTIONS = [
+  { id: "contact", title: "Contact" },
+  { id: "summary", title: "Summary" },
+  { id: "skills", title: "Skills" },
+  { id: "experience", title: "Experience" },
+  { id: "education", title: "Education" },
+  { id: "projects", title: "Projects" },
+  { id: "certifications", title: "Certifications" },
+  { id: "other", title: "Other" },
+];
+
+const BULLET_PATTERN = /^[\s>*•●◦‣▪·-]+/u;
+
+const normalizeWhitespace = (value = "") => value.replace(/\s+/g, " ").trim();
+
+const detectSection = (line) => {
+  const normalized = normalizeWhitespace(line)
+    .toLowerCase()
+    .replace(/[:.]+$/, "");
+  for (const [key, aliases] of Object.entries(SECTION_KEYWORDS)) {
+    if (aliases.some((alias) => normalized === alias || normalized.startsWith(`${alias} `))) {
+      return key;
+    }
+  }
+  return null;
+};
+
+const normalizeLine = (line) => {
+  if (!line) return "";
+  const trimmed = line.replace(/\r/g, "").trim();
+  if (!trimmed) return "";
+  if (BULLET_PATTERN.test(trimmed)) {
+    const marker = trimmed.match(BULLET_PATTERN)?.[0] ?? "";
+    const content = trimmed.slice(marker.length);
+    const normalizedContent = normalizeWhitespace(content);
+    return `${marker.replace(/\s+/g, " ").trim()} ${normalizedContent}`.trim();
+  }
+  return normalizeWhitespace(trimmed);
+};
+
+const deriveSections = (lines, plainText) => {
+  const sections = {
+    contact: [],
+    summary: [],
+    skills: [],
+    experience: [],
+    education: [],
+    projects: [],
+    certifications: [],
+    other: [],
+  };
+
+  let current = "summary";
+  let encounteredHeading = false;
+
+  for (const line of lines) {
+    const heading = detectSection(line);
+    if (heading) {
+      current = heading;
+      encounteredHeading = true;
+      continue;
+    }
+
+    if (!encounteredHeading && sections.contact.length < 6) {
+      sections.contact.push(line);
+      continue;
+    }
+
+    if (current === "contact") {
+      if (sections.contact.length < 8) {
+        sections.contact.push(line);
+      }
+      continue;
+    }
+
+    if (!sections[current]) {
+      current = "other";
+    }
+
+    sections[current].push(line);
+  }
+
+  if (sections.summary.length === 0 && plainText) {
+    const paragraphs = plainText
+      .split(/\n{2,}/)
+      .map((segment) => normalizeWhitespace(segment))
+      .filter(Boolean);
+    if (paragraphs.length > 0) {
+      sections.summary.push(paragraphs[0]);
+    }
+  }
+
+  if (sections.contact.length < 3 && plainText) {
+    const candidates = plainText
+      .split(/\n/)
+      .map((segment) => normalizeWhitespace(segment))
+      .filter((segment) =>
+        /@|\b(?:linkedin|github|behance|riyadh|ksa|saudi)\b|\+?\d{3}/i.test(segment),
+      );
+    for (const candidate of candidates) {
+      if (!sections.contact.includes(candidate) && sections.contact.length < 8) {
+        sections.contact.push(candidate);
+      }
+    }
+  }
+
+  const compacted = ORDERED_SECTIONS.map(({ id, title }) => ({
+    id,
+    title,
+    content: sections[id] ?? [],
+  })).filter((section) => section.content.length > 0 || section.id === "contact");
+
+  return compacted;
+};
+
+export const buildResumeDocument = (input = "") => {
+  const raw = typeof input === "string" ? input : "";
+  const normalizedNewlines = raw.replace(/\r\n/g, "\n");
+  const lines = normalizedNewlines
+    .split(/\n/)
+    .map((line) => normalizeLine(line))
+    .filter(Boolean);
+
+  const plainText = lines.join("\n");
+  const bullets = lines.filter((line) => BULLET_PATTERN.test(line));
+  const sections = deriveSections(lines, normalizedNewlines);
+
+  return { sections, bullets, plainText };
+};
+
+export { ORDERED_SECTIONS };

--- a/src/__tests__/JobMatch.test.jsx
+++ b/src/__tests__/JobMatch.test.jsx
@@ -28,6 +28,7 @@ describe('JobMatch', () => {
     expect(screen.getByText(/top missing keywords/i)).toBeInTheDocument();
     expect(screen.getByText(/recognized strengths/i)).toBeInTheDocument();
     expect(screen.getByText(/add react experience/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /why/i })).toBeInTheDocument();
   });
 
   it('prefills saved job description text', () => {
@@ -45,5 +46,6 @@ describe('JobMatch', () => {
     expect(
       screen.getByPlaceholderText(/paste the job description/i)
     ).toHaveValue('Saved JD');
+    expect(screen.getByText(/paste a job description to see match insights here/i)).toBeInTheDocument();
   });
 });

--- a/src/__tests__/ResumeUpload.test.jsx
+++ b/src/__tests__/ResumeUpload.test.jsx
@@ -36,9 +36,7 @@ describe('ResumeUpload', () => {
     fireEvent.change(textarea, { target: { value: '%PDF-1.5' } });
 
     expect(textarea).toHaveValue('');
-    expect(
-      screen.getByText(/this looks like a pdf\. use upload instead so we can parse it\./i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/this looks like a pdf — use upload\./i)).toBeInTheDocument();
     expect(onToast).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
+++ b/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
 <div>
   <section
     aria-live="polite"
-    class="space-y-6 rounded-[var(--radius-card)] border border-secondary-500/10 bg-white/80 p-8 text-ink-700 shadow-card backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50"
+    class="space-y-6 rounded-[var(--radius-card)] border border-secondary-500/10 bg-sand-50/95 p-8 text-ink-700 shadow-card backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50"
   >
     <div
       class="space-y-2 text-left"
@@ -37,7 +37,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
         Max 5MB
       </span>
       <div
-        class="flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-xs font-semibold text-ink-700 shadow-soft dark:bg-zinc-900/60 dark:text-surface-50"
+        class="flex items-center gap-2 rounded-full bg-sand-50/90 px-4 py-2 text-xs font-semibold text-ink-700 shadow-soft dark:bg-zinc-900/60 dark:text-surface-50"
       >
         <svg
           aria-hidden="true"
@@ -163,7 +163,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
         Paste resume text instead
       </span>
       <textarea
-        class="min-h-[160px] w-full resize-y rounded-2xl border border-secondary-500/25 bg-white/80 px-4 py-3 text-sm leading-relaxed text-ink-700 shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:border-surface-50/15 dark:bg-zinc-900/60 dark:text-surface-50 dark:focus-visible:ring-offset-zinc-900"
+        class="min-h-[160px] w-full resize-y rounded-2xl border border-secondary-500/25 bg-sand-50/95 px-4 py-3 text-sm leading-relaxed text-ink-700 shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:border-surface-50/15 dark:bg-zinc-900/60 dark:text-surface-50 dark:focus-visible:ring-offset-zinc-900"
         placeholder="Paste resume text…"
       />
     </label>

--- a/src/components/Features/JobMatch.jsx
+++ b/src/components/Features/JobMatch.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { AlertCircle, Loader2, Sparkles } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AlertCircle, Info, Loader2, Sparkles } from "lucide-react";
 import PrimaryButton from "../ui/PrimaryButton.jsx";
 import SectionTitle from "../ui/SectionTitle.jsx";
 
@@ -29,7 +29,7 @@ const resolveVariant = (score) => {
 };
 
 const formatPercent = (value) => {
-  if (!Number.isFinite(value)) return "0%";
+  if (!Number.isFinite(value)) return "—";
   return `${Math.round(value * 100)}%`;
 };
 
@@ -74,17 +74,20 @@ export default function JobMatch({
   };
 
   const hasResults = Boolean(matchAnalysis);
-  const score = matchAnalysis?.score ?? 0;
-  const variant = resolveVariant(score);
-  const progress = Math.max(0, Math.min(100, score));
+  const rawScore = Number.isFinite(matchAnalysis?.score) ? matchAnalysis.score : null;
+  const score = rawScore != null ? Math.max(0, Math.min(100, Math.round(rawScore))) : null;
+  const variant = resolveVariant(score ?? 0);
+  const progress = score == null ? 0 : Math.max(0, Math.min(100, score));
   const ringOffset = useMemo(
     () => RING_CIRCUMFERENCE - (progress / 100) * RING_CIRCUMFERENCE,
     [progress],
   );
   const missing = matchAnalysis?.missingKeywords?.slice(0, 6) ?? [];
   const hits = matchAnalysis?.topHits?.slice(0, 6) ?? [];
-  const coverageLabel = formatPercent(matchAnalysis?.coverage ?? 0);
-  const cosineLabel = `${Math.round((matchAnalysis?.cosine ?? 0) * 100) / 100}`;
+  const coverageLabel = formatPercent(matchAnalysis?.coverage);
+  const cosineLabel = formatPercent(matchAnalysis?.cosine);
+  const popoverRef = useRef(null);
+  const [whyOpen, setWhyOpen] = useState(false);
 
   const buttonDisabled = !jobText.trim() || !hasResume || isAnalyzing;
   const disabledHint = !hasResume
@@ -92,6 +95,17 @@ export default function JobMatch({
     : !jobText.trim()
     ? "Paste a job description to continue."
     : "";
+
+  useEffect(() => {
+    if (!whyOpen) return undefined;
+    const handleClick = (event) => {
+      if (!popoverRef.current?.contains(event.target)) {
+        setWhyOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [whyOpen]);
 
   return (
     <div className="grid gap-8 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
@@ -102,7 +116,7 @@ export default function JobMatch({
           description="Paste the job description to uncover keyword gaps and alignment opportunities."
         />
         <textarea
-          className="min-h-[220px] w-full rounded-[var(--radius-card)] border border-secondary-500/25 bg-white/80 px-5 py-4 text-sm leading-relaxed text-ink-700 shadow-inner transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:border-surface-50/15 dark:bg-zinc-900/60 dark:text-surface-50 dark:focus-visible:ring-offset-zinc-900"
+          className="min-h-[220px] w-full rounded-[var(--radius-card)] border border-secondary-500/25 bg-sand-50/95 px-5 py-4 text-sm leading-relaxed text-ink-700 shadow-inner transition-shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:border-surface-50/15 dark:bg-zinc-900/60 dark:text-surface-50 dark:focus-visible:ring-offset-zinc-900"
           placeholder="Paste the job description for your next Riyadh role…"
           value={jobText}
           onChange={(event) => setJobText(event.target.value)}
@@ -127,7 +141,7 @@ export default function JobMatch({
         </div>
       </div>
 
-      <aside className="relative space-y-5 rounded-[var(--radius-card)] border border-secondary-500/12 bg-white/80 p-6 text-ink-700 shadow-soft backdrop-blur-sm transition-shadow sm:p-7 sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50">
+      <aside className="relative space-y-5 rounded-[var(--radius-card)] border border-secondary-500/12 bg-sand-50/95 p-6 text-ink-700 shadow-soft backdrop-blur-sm transition-shadow sm:p-7 sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50">
         {isAnalyzing ? (
           <div className="flex h-full min-h-[280px] flex-col items-center justify-center gap-3 text-sm text-ink-500/80 dark:text-surface-50/70">
             <Loader2 className="h-6 w-6 animate-spin text-secondary-500" aria-hidden="true" />
@@ -170,18 +184,20 @@ export default function JobMatch({
                       />
                     </svg>
                     <div
-                      className="relative grid h-full w-full place-items-center rounded-full border border-surface-50/20 bg-white/10 p-4 text-ink-900 dark:bg-zinc-900/40"
+                      className="relative grid h-full w-full place-items-center rounded-full border border-surface-50/20 bg-sand-50/30 p-4 text-ink-900 dark:bg-zinc-900/40"
                       style={{
                         backgroundImage: `conic-gradient(${variant.conic} ${(progress / 100) * 360}deg, rgba(255,255,255,0.08) 0deg)`,
                       }}
                     >
-                      <div className="grid place-items-center rounded-full bg-white/90 px-6 py-6 text-center text-ink-900 shadow-inner dark:bg-zinc-900/70 dark:text-surface-50">
+                      <div className="grid place-items-center rounded-full bg-sand-50 px-6 py-6 text-center text-ink-900 shadow-inner dark:bg-zinc-900/70 dark:text-surface-50">
                         <span className="text-xs font-semibold uppercase tracking-[0.28em] text-secondary-500/80">
                           Match
                         </span>
                         <span className="mt-2 text-4xl font-bold tracking-tight">
-                          {score}
-                          <span className="text-base font-semibold text-ink-500/70 dark:text-surface-50/70">/100</span>
+                          {score == null ? "—" : score}
+                          {score != null && (
+                            <span className="text-base font-semibold text-ink-500/70 dark:text-surface-50/70">/100</span>
+                          )}
                         </span>
                       </div>
                     </div>
@@ -195,16 +211,61 @@ export default function JobMatch({
                   <p className="text-sm text-surface-50/80">
                     Weighted by cosine similarity and keyword coverage for the pasted description.
                   </p>
-                  <dl className="grid grid-cols-2 gap-3 text-xs text-surface-50/80">
-                    <div className="space-y-1 rounded-2xl bg-surface-50/10 px-3 py-2">
-                      <dt className="font-semibold uppercase tracking-[0.3em] text-surface-50/60">Coverage</dt>
-                      <dd className="text-sm font-semibold text-surface-50">{coverageLabel}</dd>
-                    </div>
-                    <div className="space-y-1 rounded-2xl bg-surface-50/10 px-3 py-2">
-                      <dt className="font-semibold uppercase tracking-[0.3em] text-surface-50/60">Similarity</dt>
-                      <dd className="text-sm font-semibold text-surface-50">{cosineLabel}</dd>
-                    </div>
-                  </dl>
+                  <div className="relative" ref={popoverRef}>
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-2 rounded-full border border-surface-50/30 bg-surface-50/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-surface-50 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-300 focus-visible:ring-offset-2 focus-visible:ring-offset-secondary-900"
+                      onClick={() => setWhyOpen((prev) => !prev)}
+                      aria-expanded={whyOpen}
+                      aria-controls="match-why-popover"
+                    >
+                      <Info className="h-3.5 w-3.5" aria-hidden="true" /> Why
+                    </button>
+                    {whyOpen && (
+                      <div
+                        id="match-why-popover"
+                        role="dialog"
+                        className="absolute right-0 z-20 mt-3 w-72 space-y-3 rounded-2xl border border-secondary-500/20 bg-sand-50/95 p-4 text-left text-sm text-ink-700 shadow-xl dark:border-secondary-500/25 dark:bg-zinc-900/80 dark:text-surface-50"
+                      >
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-secondary-500">Coverage</p>
+                          <span className="text-sm font-semibold text-ink-900 dark:text-surface-50">{coverageLabel}</span>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-secondary-500">Similarity</p>
+                          <span className="text-sm font-semibold text-ink-900 dark:text-surface-50">{cosineLabel}</span>
+                        </div>
+                        {missing.length > 0 && (
+                          <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-secondary-500">Missing</p>
+                            <ul className="mt-2 space-y-1 text-xs leading-snug text-ink-600 dark:text-surface-50/80">
+                              {missing.slice(0, 4).map((keyword) => (
+                                <li key={keyword}>• {keyword}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                        {matchAnalysis?.explanation?.reason && (
+                          <p className="text-xs text-ink-500 dark:text-surface-50/70">
+                            {matchAnalysis.explanation.reason}
+                          </p>
+                        )}
+                        {Array.isArray(matchAnalysis?.explanation?.tips) &&
+                          matchAnalysis.explanation.tips.length > 0 && (
+                            <ul className="space-y-1 text-xs leading-snug text-ink-600 dark:text-surface-50/80">
+                              {matchAnalysis.explanation.tips.slice(0, 3).map((tip, index) => (
+                                <li key={`${tip}-${index}`}>• {tip}</li>
+                              ))}
+                            </ul>
+                          )}
+                      </div>
+                    )}
+                  </div>
+                  {score == null && (
+                    <p className="text-xs font-semibold uppercase tracking-[0.28em] text-surface-50/70">
+                      — Not enough data
+                    </p>
+                  )}
                 </div>
               </div>
             </div>
@@ -255,7 +316,7 @@ export default function JobMatch({
                   {matchAnalysis.suggestions.map((suggestion, index) => (
                     <li
                       key={index}
-                      className="rounded-2xl border border-secondary-500/12 bg-white/80 px-4 py-3 shadow-soft dark:border-surface-50/10 dark:bg-zinc-900/60"
+                      className="rounded-2xl border border-secondary-500/12 bg-sand-50/95 px-4 py-3 shadow-soft dark:border-surface-50/10 dark:bg-zinc-900/60"
                     >
                       {suggestion}
                     </li>

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -181,22 +181,22 @@ export default function Header() {
               </p>
             </div>
             <dl className="grid grid-cols-1 gap-4 text-left sm:grid-cols-3">
-              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-white/80 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70">
+              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-sand-50/95 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-sand-50 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70">
                 <dt className="text-[11px] font-semibold uppercase tracking-[0.32em] text-ink-500 dark:text-surface-50/70">Smart Parsing</dt>
                 <dd className="mt-2 text-lg font-semibold text-ink-900 dark:text-surface-50">Clean resume text</dd>
               </div>
-              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-white/80 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70">
+              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-sand-50/95 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-sand-50 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70">
                 <dt className="text-[11px] font-semibold uppercase tracking-[0.32em] text-ink-500 dark:text-surface-50/70">Match Score</dt>
                 <dd className="mt-2 text-lg font-semibold text-ink-900 dark:text-surface-50">Saudi market fit</dd>
               </div>
-              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-white/80 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70">
+              <div className="card-glow group rounded-2xl border border-surface-50/20 bg-sand-50/95 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-sand-50 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70">
                 <dt className="text-[11px] font-semibold uppercase tracking-[0.32em] text-ink-500 dark:text-surface-50/70">Polished Output</dt>
                 <dd className="mt-2 text-lg font-semibold text-ink-900 dark:text-surface-50">Optimized insights</dd>
               </div>
             </dl>
           </div>
 
-          <div className="card-glow group rounded-[var(--radius-card)] border border-surface-50/20 bg-white/80 p-6 text-ink-700 shadow-md backdrop-blur-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-white/90 hover:shadow-lg sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70">
+          <div className="card-glow group rounded-[var(--radius-card)] border border-surface-50/20 bg-sand-50/95 p-6 text-ink-700 shadow-md backdrop-blur-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-sand-50 hover:shadow-lg sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70">
             <h2 className="text-lg font-semibold tracking-wide text-ink-900 dark:text-surface-50">Your Saudi-ready workflow</h2>
             <ul className="mt-6 space-y-5 text-sm text-ink-500 dark:text-surface-50/85">
               <li className="flex gap-3">

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -206,7 +206,7 @@ export default function MainContent() {
 
   const handleAnalyzeMatch = useCallback(
     async (jobDescriptionInput) => {
-      if (!resumeData) {
+      if (!resumeData?.plainText) {
         const error = new Error("Please upload or paste a resume first.");
         pushToast({
           type: "warning",
@@ -265,7 +265,7 @@ export default function MainContent() {
 
   const handleOptimize = useCallback(
     async (mode) => {
-      if (!resumeData || !jobDescription) {
+      if (!resumeData?.plainText || !jobDescription) {
         pushToast({
           type: "warning",
           title: "Add job context",
@@ -288,7 +288,7 @@ export default function MainContent() {
 
         const result = await optimizeResume(
           {
-            resumeText: resumeData,
+            resumeText: resumeData.plainText,
             jobDesc: jobDescription,
             mode,
             preview: !isPremium,
@@ -380,8 +380,9 @@ export default function MainContent() {
     });
   }, [pushToast]);
 
-  const handleExportPdf = useCallback(() => {
-    if (!resumeData) {
+  const handleExportPdf = useCallback(
+    (variant) => {
+      if (!resumeData?.plainText) {
       pushToast({
         type: "warning",
         title: "Add your resume",
@@ -392,11 +393,12 @@ export default function MainContent() {
 
     try {
       exportResumeToPdf({
-        resumeText: resumeData,
+        resumeDocument: resumeData,
         jobDescription,
         matchAnalysis,
         optimizations,
         keywords: optimizationKeywords,
+        variant,
       });
       pushToast({
         type: "success",
@@ -430,11 +432,11 @@ export default function MainContent() {
     <div className="space-y-6 text-ink-700 sm:space-y-8 dark:text-surface-50">
       <Tabs tabs={tabs} activeValue={activeTab} onTabChange={handleTabChange} />
       <div className="accent-divider mx-auto my-2 h-px w-full opacity-80" aria-hidden="true" />
-      <div className="relative min-h-[460px] rounded-[var(--radius-card)] border border-secondary-500/12 bg-white/80 p-6 shadow-card backdrop-blur-sm transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_22px_65px_-40px_rgba(15,15,18,0.55)] sm:min-h-[520px] sm:p-7 sm:backdrop-blur-xl lg:p-8 dark:border-surface-50/12 dark:bg-zinc-900/60">
+      <div className="relative min-h-[460px] rounded-[var(--radius-card)] border border-secondary-500/12 bg-sand-50/95 p-6 shadow-card backdrop-blur-sm transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_22px_65px_-40px_rgba(15,15,18,0.55)] sm:min-h-[520px] sm:p-7 sm:backdrop-blur-xl lg:p-8 dark:border-surface-50/12 dark:bg-zinc-900/60">
         {activeTab === "resume" && (
           <ResumeUpload
             onParseResume={handleParseResume}
-            resumeData={resumeData}
+            resumeDocument={resumeData}
             onToast={handleUploadToast}
           />
         )}
@@ -443,7 +445,7 @@ export default function MainContent() {
             onAnalyzeMatch={handleAnalyzeMatch}
             matchAnalysis={matchAnalysis}
             isAnalyzing={isAnalyzing}
-            hasResume={Boolean(resumeData)}
+            hasResume={Boolean(resumeData?.plainText)}
           />
         )}
         {activeTab === "optimize" && (
@@ -457,7 +459,7 @@ export default function MainContent() {
             previewUsed={previewUsed}
             onUpgrade={handleUpgrade}
             onExport={handleExportPdf}
-            canExport={Boolean(resumeData)}
+            canExport={Boolean(resumeData?.plainText)}
           />
         )}
       </div>
@@ -478,7 +480,7 @@ export default function MainContent() {
     >
       <ToastContainer>{renderedToasts}</ToastContainer>
       <div className={`${containerClass} space-y-8 text-ink-700 sm:space-y-10 lg:space-y-12 dark:text-surface-50`}>
-        <div className="card-glow rounded-[var(--radius-card)] border border-secondary-500/12 bg-white/80 p-6 shadow-card backdrop-blur-sm transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_24px_70px_-42px_rgba(15,15,18,0.58)] sm:p-8 sm:backdrop-blur-xl lg:p-9 dark:border-surface-50/12 dark:bg-zinc-900/60">
+        <div className="card-glow rounded-[var(--radius-card)] border border-secondary-500/12 bg-sand-50/95 p-6 shadow-card backdrop-blur-sm transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_24px_70px_-42px_rgba(15,15,18,0.58)] sm:p-8 sm:backdrop-blur-xl lg:p-9 dark:border-surface-50/12 dark:bg-zinc-900/60">
           {flowProgress > 0 && (
             <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-smoke-50/70 dark:bg-zinc-900/50">
               <div
@@ -513,7 +515,7 @@ export default function MainContent() {
         </div>
         {isDev && aiDebug && (
           <section className="text-xs text-ink-500 dark:text-surface-50/70">
-            <div className="rounded-[var(--radius-card)] border border-secondary-500/20 bg-white/80 p-4 shadow-soft backdrop-blur-sm sm:p-5 sm:backdrop-blur-xl dark:border-surface-50/15 dark:bg-zinc-900/60">
+            <div className="rounded-[var(--radius-card)] border border-secondary-500/20 bg-sand-50/95 p-4 shadow-soft backdrop-blur-sm sm:p-5 sm:backdrop-blur-xl dark:border-surface-50/15 dark:bg-zinc-900/60">
               <p className="font-semibold uppercase tracking-[0.24em] text-secondary-500">AI Debug</p>
               <dl className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-7">
                 <div>

--- a/src/components/shared/CommonComponents.jsx
+++ b/src/components/shared/CommonComponents.jsx
@@ -7,7 +7,7 @@ export function Card({ children, className }) {
   return (
     <div
       className={cn(
-        "rounded-[var(--radius-card)] border border-secondary-500/10 bg-white/80 p-6 shadow-soft backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60",
+    "rounded-[var(--radius-card)] border border-secondary-500/10 bg-sand-50/95 p-6 shadow-soft backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60",
         className
       )}
     >

--- a/src/components/shared/OptimizationCard.jsx
+++ b/src/components/shared/OptimizationCard.jsx
@@ -13,7 +13,7 @@ export default function OptimizationCard({ card, onCopy, disabledActions = false
   };
 
   return (
-    <article className="relative space-y-5 rounded-[var(--radius-card)] border border-secondary-500/12 bg-white/80 p-6 shadow-soft backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-lg dark:border-surface-50/10 dark:bg-zinc-900/65 dark:text-surface-50 dark:hover:bg-zinc-900/70">
+    <article className="relative space-y-5 rounded-[var(--radius-card)] border border-secondary-500/12 bg-sand-50/95 p-6 shadow-soft backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-lg dark:border-surface-50/10 dark:bg-zinc-900/65 dark:text-surface-50 dark:hover:bg-zinc-900/70">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div className="flex items-center gap-3">
           <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-secondary-500/10 text-secondary-500">

--- a/src/components/ui/EmptyState.jsx
+++ b/src/components/ui/EmptyState.jsx
@@ -4,7 +4,7 @@ export default function EmptyState({ icon: Icon, title, description, actions, cl
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center gap-6 rounded-[var(--radius-card)] border border-secondary-500/10 bg-white/80 px-8 py-16 text-center shadow-soft backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60",
+    "flex flex-col items-center justify-center gap-6 rounded-[var(--radius-card)] border border-secondary-500/10 bg-sand-50/95 px-8 py-16 text-center shadow-soft backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60",
         className
       )}
     >

--- a/src/components/ui/Tabs.jsx
+++ b/src/components/ui/Tabs.jsx
@@ -61,7 +61,7 @@ export default function Tabs({ tabs, activeValue, onTabChange }) {
     <div
       role="tablist"
       aria-label="Resume workflow navigation"
-      className="relative flex flex-wrap items-center justify-between gap-2 rounded-[calc(var(--radius-card)*1.2)] border border-secondary-500/10 bg-white/75 p-1.5 text-ink-700 backdrop-blur-sm dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50"
+      className="relative flex flex-wrap items-center justify-between gap-2 rounded-[calc(var(--radius-card)*1.2)] border border-secondary-500/10 bg-sand-50/90 p-1.5 text-ink-700 backdrop-blur-sm dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50"
     >
       {tabs.map(({ value, label, icon: Icon }, index) => {
         const isActive = value === activeValue;
@@ -80,7 +80,7 @@ export default function Tabs({ tabs, activeValue, onTabChange }) {
             className={cn(
               "group tab-pattern-hover relative flex flex-1 items-center justify-center gap-2 overflow-hidden rounded-[calc(var(--radius-card)*0.85)] px-4 py-3 text-sm font-semibold transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:focus-visible:ring-offset-zinc-900",
               isActive
-                ? "bg-white/90 text-ink-900 shadow-soft dark:bg-zinc-900/70 dark:text-surface-50"
+                ? "bg-sand-50 text-ink-900 shadow-soft dark:bg-zinc-900/70 dark:text-surface-50"
                 : "text-ink-500/80 hover:bg-secondary-500/10 hover:text-ink-700 dark:text-surface-50/60 dark:hover:bg-secondary-500/15"
             )}
             style={{ "--tab-pattern": `url("data:image/svg+xml,${tabPattern}")` }}

--- a/src/components/ui/UploadCard.jsx
+++ b/src/components/ui/UploadCard.jsx
@@ -54,7 +54,7 @@ export default function UploadCard({
 
   return (
     <section
-      className="space-y-6 rounded-[var(--radius-card)] border border-secondary-500/10 bg-white/80 p-8 text-ink-700 shadow-card backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50"
+      className="space-y-6 rounded-[var(--radius-card)] border border-secondary-500/10 bg-sand-50/95 p-8 text-ink-700 shadow-card backdrop-blur-sm sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50"
       aria-live="polite"
     >
       <div className="space-y-2 text-left">
@@ -87,7 +87,7 @@ export default function UploadCard({
         <span className="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full bg-secondary-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-secondary-500">
           Max 5MB
         </span>
-        <div className="flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-xs font-semibold text-ink-700 shadow-soft dark:bg-zinc-900/60 dark:text-surface-50">
+        <div className="flex items-center gap-2 rounded-full bg-sand-50/90 px-4 py-2 text-xs font-semibold text-ink-700 shadow-soft dark:bg-zinc-900/60 dark:text-surface-50">
           <FileText className="h-4 w-4" aria-hidden="true" />
           <span>PDF</span>
           <span className="mx-1 text-ink-500/60">|</span>
@@ -132,7 +132,7 @@ export default function UploadCard({
           Paste resume text instead
         </span>
         <textarea
-          className="min-h-[160px] w-full resize-y rounded-2xl border border-secondary-500/25 bg-white/80 px-4 py-3 text-sm leading-relaxed text-ink-700 shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:border-surface-50/15 dark:bg-zinc-900/60 dark:text-surface-50 dark:focus-visible:ring-offset-zinc-900"
+          className="min-h-[160px] w-full resize-y rounded-2xl border border-secondary-500/25 bg-sand-50/95 px-4 py-3 text-sm leading-relaxed text-ink-700 shadow-inner focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:border-surface-50/15 dark:bg-zinc-900/60 dark:text-surface-50 dark:focus-visible:ring-offset-zinc-900"
           placeholder="Paste resume text…"
           value={textValue}
           onChange={(event) => onTextChange?.(event.target.value)}

--- a/src/features/Optimization.jsx
+++ b/src/features/Optimization.jsx
@@ -103,7 +103,7 @@ export default function Optimization({
           <select
             value={mode}
             onChange={(event) => setMode(event.target.value)}
-            className="w-full rounded-[var(--radius-card)] border border-secondary-500/25 bg-white/80 px-4 py-3 text-sm font-medium text-ink-700 shadow-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:border-surface-50/15 dark:bg-zinc-900/60 dark:text-surface-50 dark:focus-visible:ring-offset-zinc-900"
+            className="w-full rounded-[var(--radius-card)] border border-secondary-500/25 bg-sand-50/95 px-4 py-3 text-sm font-medium text-ink-700 shadow-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-sand-50 dark:border-surface-50/15 dark:bg-zinc-900/60 dark:text-surface-50 dark:focus-visible:ring-offset-zinc-900"
           >
             {modes.map((option) => (
               <option key={option.value} value={option.value}>
@@ -117,7 +117,7 @@ export default function Optimization({
           <div className="flex flex-wrap gap-2">
             <SecondaryButton
               icon={FileDown}
-              onClick={() => onExport?.()}
+              onClick={() => onExport?.("styled")}
               disabled={!canExport || isOptimizing}
               title={
                 !canExport
@@ -127,7 +127,21 @@ export default function Optimization({
                   : undefined
               }
             >
-              Export PDF
+              Styled PDF
+            </SecondaryButton>
+            <SecondaryButton
+              icon={FileDown}
+              onClick={() => onExport?.("ats")}
+              disabled={!canExport || isOptimizing}
+              title={
+                !canExport
+                  ? "Upload and parse your resume before exporting."
+                  : isOptimizing
+                  ? "Please wait for the optimization run to finish."
+                  : undefined
+              }
+            >
+              ATS PDF
             </SecondaryButton>
             <SecondaryButton
               icon={Check}
@@ -168,7 +182,7 @@ export default function Optimization({
       </PrimaryButton>
 
       <section className="space-y-4">
-        <div className="rounded-[var(--radius-card)] border border-secondary-500/12 bg-white/80 p-5 shadow-soft dark:border-surface-50/10 dark:bg-zinc-900/60">
+        <div className="rounded-[var(--radius-card)] border border-secondary-500/12 bg-sand-50/95 p-5 shadow-soft dark:border-surface-50/10 dark:bg-zinc-900/60">
           <h3 className="text-sm font-semibold uppercase tracking-[0.28em] text-secondary-500">
             Keyword focus
           </h3>
@@ -211,7 +225,7 @@ export default function Optimization({
               {[...Array(3)].map((_, index) => (
                 <div
                   key={index}
-                  className="h-40 animate-pulse rounded-[var(--radius-card)] border border-secondary-500/10 bg-white/75 dark:border-surface-50/10 dark:bg-zinc-900/60"
+                  className="h-40 animate-pulse rounded-[var(--radius-card)] border border-secondary-500/10 bg-sand-50/90 dark:border-surface-50/10 dark:bg-zinc-900/60"
                 />
               ))}
             </div>

--- a/src/features/ResumeUpload.jsx
+++ b/src/features/ResumeUpload.jsx
@@ -8,9 +8,9 @@ const ACCEPTED_TYPES = [
 ];
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
-const PDF_HELPER_MESSAGE = "This looks like a PDF. Use Upload instead so we can parse it.";
+const PDF_HELPER_MESSAGE = "This looks like a PDF — use Upload.";
 
-export default function ResumeUpload({ onParseResume, resumeData, onToast }) {
+export default function ResumeUpload({ onParseResume, resumeDocument, onToast }) {
   const [file, setFile] = useState(null);
   const [textValue, setTextValue] = useState("");
   const [status, setStatus] = useState("idle");
@@ -19,11 +19,11 @@ export default function ResumeUpload({ onParseResume, resumeData, onToast }) {
   const [textWarning, setTextWarning] = useState("");
 
   useEffect(() => {
-    if (resumeData && !textValue) {
-      setTextValue(resumeData);
+    if (resumeDocument?.plainText && !textValue) {
+      setTextValue(resumeDocument.plainText);
       setTextWarning("");
     }
-  }, [resumeData, textValue]);
+  }, [resumeDocument, textValue]);
 
   const resetState = useCallback(() => {
     setFile(null);
@@ -85,13 +85,25 @@ export default function ResumeUpload({ onParseResume, resumeData, onToast }) {
   );
 
   const handleSubmit = useCallback(async () => {
-    if (!file && !textValue.trim()) {
+    const trimmedText = textValue.trim();
+
+    if (!file && !trimmedText) {
       const message = "Add a file or paste your resume text.";
       setError(message);
       onToast?.({
         type: "warning",
         title: "Resume missing",
         description: message,
+      });
+      return;
+    }
+
+    if (!file && trimmedText.startsWith("%PDF")) {
+      setTextWarning(PDF_HELPER_MESSAGE);
+      onToast?.({
+        type: "warning",
+        title: "Paste blocked",
+        description: PDF_HELPER_MESSAGE,
       });
       return;
     }
@@ -158,8 +170,8 @@ export default function ResumeUpload({ onParseResume, resumeData, onToast }) {
       const parsed = await onParseResume?.(payload);
       setProgress(100);
       setStatus("success");
-      if (!file && parsed) {
-        setTextValue(parsed);
+      if (!file && parsed?.plainText) {
+        setTextValue(parsed.plainText);
       }
       setTimeout(() => {
         setStatus("idle");

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -6,6 +6,7 @@ export const AI_DEFAULT_TEMPERATURE = 1;
 
 const FUNCTION_BASE_PATH = "/.netlify/functions";
 const MATCH_ENDPOINT = `${FUNCTION_BASE_PATH}/match-score`;
+const PARSE_ENDPOINT = `${FUNCTION_BASE_PATH}/parse-resume`;
 const REQUEST_TIMEOUT = 15000;
 const OPTIMIZATION_TIMEOUT = 45000;
 
@@ -212,16 +213,133 @@ const handleResponse = async (response) => {
 
 const sanitizeText = (value) => (typeof value === "string" ? value.trim() : "");
 
-export const parseResume = async (resumeText) => {
-  const content = sanitizeText(resumeText);
-  if (!content) {
-    throw new Error("Unable to parse resume content.");
+const fileToBase64 = async (file) => {
+  const buffer = await file.arrayBuffer();
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const slice = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...slice);
   }
-  return content.replace(/\s+/g, " ").trim();
+  if (typeof btoa === "function") {
+    return btoa(binary);
+  }
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(bytes).toString("base64");
+  }
+  throw new Error("Base64 encoding not supported in this environment.");
 };
 
-export const analyzeResume = async (resumeText, jobText, options = {}) => {
-  const resume = sanitizeText(resumeText);
+const requestMatchExplanation = async ({
+  resume,
+  job,
+  score,
+  coverage,
+  similarity,
+}) => {
+  try {
+    const system =
+      "You are a resume analyst. Respond with strict JSON {reason: string, tips: string[]} explaining the match score.";
+    const prompt =
+      `SCORE:${score}\nCOVERAGE:${coverage}\nSIMILARITY:${similarity}\n\nRESUME:\n${resume.slice(0, 2000)}\n\nJOB:\n${job.slice(0, 2000)}`;
+    const result = await runOptimization({
+      messages: [
+        {
+          role: "system",
+          content: [{ type: "text", text: system }],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: prompt }],
+        },
+      ],
+      temperature: 0.2,
+      max_output_tokens: 480,
+    });
+
+    const parsed = safeJson(result.text);
+    if (!parsed || typeof parsed !== "object") return null;
+    const reason = typeof parsed.reason === "string" ? parsed.reason.trim() : "";
+    const tips = Array.isArray(parsed.tips)
+      ? parsed.tips.map((tip) => sanitize(String(tip))).filter(Boolean).slice(0, 4)
+      : [];
+    if (!reason && tips.length === 0) {
+      return null;
+    }
+    return { reason, tips };
+  } catch {
+    return null;
+  }
+};
+
+const isFile = (value) =>
+  typeof File !== "undefined" && value instanceof File;
+
+export const parseResume = async (resumeInput) => {
+  if (!resumeInput) {
+    throw new Error("Unable to parse resume content.");
+  }
+
+  const payload = await (async () => {
+    if (isFile(resumeInput)) {
+      const encoded = await fileToBase64(resumeInput);
+      return {
+        kind: "file",
+        name: resumeInput.name,
+        mime: resumeInput.type,
+        data: encoded,
+      };
+    }
+
+    if (typeof resumeInput === "string") {
+      const trimmed = resumeInput.trim();
+      if (!trimmed) {
+        throw new Error("Unable to parse resume content.");
+      }
+      if (trimmed.startsWith("%PDF")) {
+        throw new Error("This looks like a PDF — use Upload.");
+      }
+      return { kind: "text", value: trimmed };
+    }
+
+    throw new Error("Unsupported resume input.");
+  })();
+
+  const response = await fetch(PARSE_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await handleResponse(response);
+  const document = data?.document;
+
+  if (!document || typeof document !== "object" || !document.plainText) {
+    throw new Error("Unable to parse resume content.");
+  }
+
+  return {
+    plainText: String(document.plainText),
+    bullets: Array.isArray(document.bullets) ? document.bullets.map((item) => sanitize(String(item))) : [],
+    sections: Array.isArray(document.sections)
+      ? document.sections
+          .map((section) => ({
+            id: sanitize(String(section.id ?? "")) || null,
+            title: sanitize(String(section.title ?? "")) || null,
+            content: Array.isArray(section.content)
+              ? section.content.map((item) => sanitize(String(item))).filter(Boolean)
+              : [],
+          }))
+          .filter((section) => section.title || section.content.length > 0)
+      : [],
+  };
+};
+
+export const analyzeResume = async (resumeInput, jobText, options = {}) => {
+  const resume = sanitizeText(
+    typeof resumeInput === "string" ? resumeInput : resumeInput?.plainText ?? "",
+  );
   const job = sanitizeText(jobText);
 
   if (!resume) {
@@ -247,27 +365,42 @@ export const analyzeResume = async (resumeText, jobText, options = {}) => {
     });
 
     const data = await handleResponse(response);
-    const topMissing = Array.isArray(data?.explanations?.topMissing)
-      ? data.explanations.topMissing.slice(0, 6)
+    const topMissing = Array.isArray(data?.missing_keywords)
+      ? data.missing_keywords.map((item) => sanitize(String(item))).filter(Boolean)
       : [];
-    const topHits = Array.isArray(data?.explanations?.topHits)
-      ? data.explanations.topHits.slice(0, 6)
+    const topHits = Array.isArray(data?.matched_keywords)
+      ? data.matched_keywords.map((item) => sanitize(String(item))).filter(Boolean)
       : [];
-    const coverage = Number(data?.explanations?.coverage ?? 0);
-    const cosine = Number(data?.explanations?.cosine ?? 0);
+    const coverage = Number(data?.coverage ?? 0);
+    const cosine = Number(data?.similarity ?? 0);
 
-    const suggestions = topMissing.map(
+    const suggestions = topMissing.slice(0, 6).map(
       (keyword) => `Consider highlighting “${keyword}” to better reflect the role requirements.`,
     );
 
-    return {
-      score: Number.isFinite(data?.score) ? data.score : 0,
-      missingKeywords: topMissing,
+    const baseResult = {
+      score: Number.isFinite(data?.score) ? Math.round(data.score) : 0,
+      missingKeywords: topMissing.slice(0, 12),
       suggestions,
-      topHits,
+      topHits: topHits.slice(0, 12),
       coverage,
       cosine,
     };
+
+    if (options.explain) {
+      const explanation = await requestMatchExplanation({
+        resume,
+        job,
+        score: baseResult.score,
+        coverage,
+        similarity: cosine,
+      });
+      if (explanation) {
+        return { ...baseResult, explanation };
+      }
+    }
+
+    return baseResult;
   } catch (error) {
     if (error?.name === "AbortError") {
       throw new Error("Match analysis timed out. Please try again.");

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -21,7 +21,27 @@ afterEach(() => {
 
 describe('parseResume', () => {
   it('returns trimmed text', async () => {
-    await expect(parseResume('  Sample resume  ')).resolves.toBe('Sample resume');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          document: {
+            plainText: 'Sample resume',
+            bullets: [],
+            sections: [],
+          },
+        }),
+    });
+
+    await expect(parseResume('  Sample resume  ')).resolves.toEqual({
+      plainText: 'Sample resume',
+      bullets: [],
+      sections: [],
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/.netlify/functions/parse-resume',
+      expect.objectContaining({ method: 'POST' })
+    );
   });
 
   it('throws when content empty', async () => {
@@ -36,16 +56,14 @@ describe('analyzeResume', () => {
       json: () =>
         Promise.resolve({
           score: 82,
-          explanations: {
-            topMissing: ['react', 'aws'],
-            topHits: ['leadership'],
-            coverage: 0.6,
-            cosine: 0.71,
-          },
+          coverage: 0.6,
+          similarity: 0.71,
+          missing_keywords: ['react', 'aws'],
+          matched_keywords: ['leadership'],
         }),
     });
 
-    const result = await analyzeResume('resume text', 'job text');
+    const result = await analyzeResume({ plainText: 'resume text' }, 'job text');
 
     expect(global.fetch).toHaveBeenCalledWith('/.netlify/functions/match-score', expect.objectContaining({
       method: 'POST',
@@ -68,7 +86,7 @@ describe('analyzeResume', () => {
     abortError.name = 'AbortError';
     global.fetch.mockRejectedValueOnce(abortError);
 
-    await expect(analyzeResume('resume text', 'job text')).rejects.toThrow('Match analysis timed out');
+    await expect(analyzeResume({ plainText: 'resume text' }, 'job text')).rejects.toThrow('Match analysis timed out');
   });
 });
 

--- a/src/services/exportPdf.js
+++ b/src/services/exportPdf.js
@@ -1,3 +1,5 @@
+import { buildResumeDocument } from "../../shared/normalize-resume.js";
+
 const SECTION_KEYWORDS = {
   contact: ["contact", "contact information", "personal details"],
   summary: ["summary", "professional summary", "profile", "objective", "about"],
@@ -29,6 +31,37 @@ const splitLines = (text) =>
     .split(/\r?\n/)
     .map((line) => normalize(line))
     .filter(Boolean);
+
+const sanitizeLines = (items) =>
+  Array.isArray(items)
+    ? items.map((item) => normalize(String(item ?? ""))).filter(Boolean)
+    : [];
+
+const ensureResumeDocument = (input) => {
+  if (input && typeof input === "object" && typeof input.plainText === "string") {
+    return {
+      plainText: String(input.plainText),
+      sections: Array.isArray(input.sections)
+        ? input.sections.map((section) => ({
+            id: typeof section.id === "string" ? section.id : null,
+            title: typeof section.title === "string" ? section.title : null,
+            content: sanitizeLines(section.content),
+          }))
+        : [],
+      bullets: sanitizeLines(input.bullets),
+    };
+  }
+
+  if (typeof input === "string") {
+    return buildResumeDocument(input);
+  }
+
+  if (typeof input === "object" && typeof input?.plainText === "string") {
+    return buildResumeDocument(input.plainText);
+  }
+
+  return buildResumeDocument("");
+};
 
 export const deriveResumeSections = (resumeText = "") => {
   const lines = splitLines(resumeText);
@@ -228,8 +261,9 @@ const buildContact = (lines) => {
   };
 };
 
-const buildExportHtml = ({ resumeText = "", jobDescription = "", matchAnalysis, optimizations, keywords }) => {
-  const sections = deriveResumeSections(resumeText);
+const buildExportHtml = ({ resumeDocument, resumeText = "", jobDescription = "", matchAnalysis, optimizations, keywords }) => {
+  const document = ensureResumeDocument(resumeDocument ?? resumeText);
+  const sections = deriveResumeSections(document.plainText);
   const contact = buildContact(sections.contactLines);
   const summaryHtml = buildSummary(sections.summary, matchAnalysis, optimizations);
   const skillsHtml = buildSkills(sections.skills, keywords);
@@ -285,20 +319,155 @@ const buildExportHtml = ({ resumeText = "", jobDescription = "", matchAnalysis, 
 </html>`;
 };
 
-export const exportResumeToPdf = ({ resumeText = "", jobDescription = "", matchAnalysis, optimizations, keywords }) => {
-  if (typeof window === "undefined" || typeof window.open !== "function") {
+const buildPlainExportHtml = ({
+  resumeDocument,
+  resumeText = "",
+  jobDescription = "",
+  matchAnalysis,
+  optimizations,
+}) => {
+  const document = ensureResumeDocument(resumeDocument ?? resumeText);
+  const sections = deriveResumeSections(document.plainText);
+  const contact = buildContact(sections.contactLines);
+  const summaryLines = sections.summary.length > 0 ? sections.summary : sections.experience.slice(0, 3);
+  const experienceLines = sections.experience;
+  const educationLines = sections.education;
+  const skillsLines = sections.skills;
+  const projectsLines = sections.projects;
+  const bulletLines = document.bullets.length > 0 ? document.bullets : experienceLines;
+  const optimizationBullets = Array.isArray(optimizations)
+    ? optimizations
+        .map((item) =>
+          item?.suggestion ? `• ${escapeHtml(item.section ? `${item.section}: ${item.suggestion}` : item.suggestion)}` : null,
+        )
+        .filter(Boolean)
+        .slice(0, 5)
+    : [];
+
+  const formatPercentValue = (value) =>
+    Number.isFinite(value) ? `${Math.round(value * 100)}%` : null;
+
+  const metrics = [
+    Number.isFinite(matchAnalysis?.score) ? `Score: ${Math.round(matchAnalysis.score)}/100` : null,
+    formatPercentValue(matchAnalysis?.coverage) ? `Coverage: ${formatPercentValue(matchAnalysis.coverage)}` : null,
+    formatPercentValue(matchAnalysis?.cosine) ? `Similarity: ${formatPercentValue(matchAnalysis.cosine)}` : null,
+  ].filter(Boolean);
+
+  const renderSection = (title, lines) => {
+    if (!lines || lines.length === 0) return "";
+    const content = lines.map((line) => `<p>${escapeHtml(line)}</p>`).join("");
+    return `<section><h2>${escapeHtml(title)}</h2>${content}</section>`;
+  };
+
+  const renderListSection = (title, lines) => {
+    if (!lines || lines.length === 0) return "";
+    const content = lines.map((line) => `<li>${escapeHtml(line.replace(/^•\s*/, ""))}</li>`).join("");
+    return `<section><h2>${escapeHtml(title)}</h2><ul>${content}</ul></section>`;
+  };
+
+  const contactLine = contact.entries.length > 0 ? contact.entries.join(" • ") : "Add contact information.";
+  const jdPreview = jobDescription
+    ? `<section><h2>Target Role</h2><p>${escapeHtml(jobDescription)}</p></section>`
+    : "";
+
+  const metricsLine = metrics.length > 0 ? `<p class="metrics">${metrics.map((item) => escapeHtml(item)).join(" • ")}</p>` : "";
+  const optimizationsSection =
+    optimizationBullets.length > 0
+      ? `<section><h2>AI Suggestions</h2><ul>${optimizationBullets.join("")}</ul></section>`
+      : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>ATS Resume Export</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; font-family: "Segoe UI", Arial, sans-serif; color: #111827; background: #ffffff; }
+      body { padding: 32px; }
+      main { max-width: 720px; margin: 0 auto; display: grid; gap: 24px; }
+      header { border-bottom: 2px solid #1f2937; padding-bottom: 16px; }
+      h1 { margin: 0; font-size: 28px; letter-spacing: 0.02em; text-transform: uppercase; }
+      h2 { margin: 24px 0 12px; font-size: 15px; letter-spacing: 0.18em; text-transform: uppercase; }
+      p { margin: 0 0 12px; line-height: 1.6; }
+      ul { margin: 0 0 12px 18px; padding: 0; line-height: 1.6; }
+      li { margin-bottom: 6px; }
+      .contact { font-size: 13px; color: #374151; }
+      .metrics { font-size: 12px; color: #4b5563; text-transform: uppercase; letter-spacing: 0.2em; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>${escapeHtml(contact.name)}</h1>
+        <p class="contact">${escapeHtml(contactLine)}</p>
+        ${metricsLine}
+      </header>
+      ${renderSection("Summary", summaryLines)}
+      ${renderListSection("Experience Highlights", bulletLines)}
+      ${renderSection("Skills", skillsLines)}
+      ${renderSection("Education", educationLines)}
+      ${renderSection("Projects", projectsLines)}
+      ${optimizationsSection}
+      ${jdPreview}
+    </main>
+  </body>
+</html>`;
+};
+
+const triggerPrint = (html) => {
+  if (typeof document === "undefined") {
     throw new Error("Export is only available in the browser.");
   }
-  const html = buildExportHtml({ resumeText, jobDescription, matchAnalysis, optimizations, keywords });
-  const win = window.open("", "_blank", "noopener");
-  if (!win) {
-    throw new Error("Popup blocked. Allow pop-ups to export.");
+
+  const iframe = document.createElement("iframe");
+  iframe.style.position = "fixed";
+  iframe.style.right = "0";
+  iframe.style.bottom = "0";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.border = "0";
+  document.body.appendChild(iframe);
+
+  const remove = () => {
+    iframe.parentNode?.removeChild(iframe);
+  };
+
+  const frameDocument = iframe.contentWindow?.document || iframe.contentDocument;
+  if (!frameDocument) {
+    remove();
+    throw new Error("Unable to prepare export frame.");
   }
-  win.document.write(html);
-  win.document.close();
-  win.focus();
-  win.print();
+
+  frameDocument.open();
+  frameDocument.write(html);
+  frameDocument.close();
+
+  setTimeout(() => {
+    const frameWindow = iframe.contentWindow;
+    if (!frameWindow) {
+      remove();
+      return;
+    }
+    frameWindow.focus();
+    frameWindow.print();
+    setTimeout(remove, 800);
+  }, 220);
+};
+
+export const exportResumeToPdf = ({
+  resumeDocument,
+  resumeText = "",
+  jobDescription = "",
+  matchAnalysis,
+  optimizations,
+  keywords,
+  variant = "styled",
+}) => {
+  const payload = { resumeDocument, resumeText, jobDescription, matchAnalysis, optimizations, keywords };
+  const html = variant === "ats" ? buildPlainExportHtml(payload) : buildExportHtml(payload);
+  triggerPrint(html);
   return true;
 };
 
-export { buildExportHtml };
+export { buildExportHtml, buildPlainExportHtml };

--- a/src/services/exportPdf.test.js
+++ b/src/services/exportPdf.test.js
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { deriveResumeSections, buildExportHtml, exportResumeToPdf } from "./exportPdf";
+import { describe, expect, it, vi } from "vitest";
+import { deriveResumeSections, buildExportHtml, buildPlainExportHtml, exportResumeToPdf } from "./exportPdf";
 
 describe("exportPdf", () => {
   const sampleResume = `John Doe
@@ -32,7 +32,7 @@ Vision 2030 Dashboard – Built analytics portal for executive leadership.`;
 
   it("builds printable html template", () => {
     const html = buildExportHtml({
-      resumeText: sampleResume,
+      resumeDocument: { plainText: sampleResume },
       jobDescription: "Lead product manager for Riyadh digital bank.",
       matchAnalysis: { score: 82, coverage: 0.74, cosine: 0.81 },
       optimizations: [
@@ -50,9 +50,36 @@ Vision 2030 Dashboard – Built analytics portal for executive leadership.`;
     expect(html).toContain("Match Score");
   });
 
+  it("builds ATS-friendly export html", () => {
+    const html = buildPlainExportHtml({
+      resumeDocument: { plainText: sampleResume, bullets: ["• Launched product"], sections: [] },
+      jobDescription: "Modern banking lead.",
+      matchAnalysis: { score: 70, coverage: 0.5, cosine: 0.62 },
+      optimizations: [
+        {
+          section: "Experience",
+          suggestion: "Highlight Vision 2030 impact",
+        },
+      ],
+    });
+
+    expect(html).toContain("ATS Resume Export");
+    expect(html).toContain("Experience Highlights");
+    expect(html).toContain("AI Suggestions");
+  });
+
   it("throws in non-browser environments", () => {
-    expect(() => exportResumeToPdf({ resumeText: sampleResume })).toThrow(
-      /Export is only available in the browser|Popup blocked/,
-    );
+    const originalDocument = globalThis.document;
+    vi.stubGlobal("document", undefined);
+
+    try {
+      expect(() => exportResumeToPdf({ resumeDocument: { plainText: sampleResume } })).toThrow(
+        /Export is only available in the browser/,
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(globalThis.document).toBe(originalDocument);
   });
 });


### PR DESCRIPTION
## Summary
- add a Netlify `parse-resume` function and shared normalizer so uploads and pasted resumes go through the same text pipeline
- provide both styled and ATS-friendly printable exports with the new iframe print flow and theme updates across match/optimization surfaces
- deliver deterministic match scoring (coverage + cosine) with an optional explanation call and refreshed client UX for the "Why" breakdown

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55893192c83308aa3cfdeca0a0a28