### PR TITLE
feat: polish layout gradient and ATS export

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -68,7 +68,7 @@ export default function Header() {
 
   return (
     <header
-      className="hero-bg-animate relative isolate flex min-h-screen min-h-[100svh] flex-col justify-between gap-10 overflow-hidden text-surface-50 pb-16 pt-10 sm:gap-12 sm:pb-24 sm:pt-16 md:min-h-[100dvh]"
+      className="hero-bg-animate relative isolate flex min-h-screen min-h-[100svh] flex-col justify-between gap-8 overflow-hidden text-surface-50 pb-16 pt-12 sm:gap-12 sm:pb-24 sm:pt-20 md:min-h-[100dvh] lg:pb-28 lg:pt-24"
     >
       {typeof skylineUrl === "string" && skylineUrl ? (
         <div
@@ -103,7 +103,7 @@ export default function Header() {
 
       <div className="relative z-10 flex flex-1 flex-col">
         <div className="border-b border-surface-50/10">
-          <div className={`${containerClass} flex items-center justify-between py-4`}>
+          <div className={`${containerClass} flex items-center justify-between gap-4 py-4 sm:py-6`}>
             <div className="flex items-center gap-3">
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-surface-50/10 text-accent-500 shadow-soft">
                 <Sparkles className="h-5 w-5" aria-hidden="true" />
@@ -157,9 +157,9 @@ export default function Header() {
         </div>
 
         <div
-          className={`${containerClass} grid flex-1 items-center gap-10 pb-16 pt-12 sm:gap-12 sm:pt-14 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] lg:gap-16 lg:pb-20 lg:pt-16`}
+          className={`${containerClass} grid flex-1 items-center gap-10 pb-16 pt-10 sm:gap-12 sm:pt-14 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] lg:gap-16 lg:pb-20 lg:pt-16`}
         >
-          <div className="space-y-6">
+          <div className="space-y-6 sm:space-y-7">
             <span
               tabIndex={0}
               className="badge-gold-shimmer inline-flex items-center gap-2 self-center rounded-full border border-surface-50/35 bg-surface-900/60 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] backdrop-blur-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent text-shadow-hero sm:self-start"
@@ -173,10 +173,10 @@ export default function Header() {
               >
                 <Sparkles className="h-7 w-7" />
               </span>
-              <h1 className="text-shadow-hero text-4xl font-bold leading-tight tracking-tight drop-shadow-[0_16px_34px_rgba(0,0,0,0.6)] sm:text-5xl lg:text-6xl">
+              <h1 className="text-balance text-shadow-hero text-4xl font-bold leading-tight tracking-tight drop-shadow-[0_16px_34px_rgba(0,0,0,0.6)] sm:text-5xl lg:text-6xl">
                 AI Resume Optimizer
               </h1>
-              <p className="text-pretty text-shadow-hero mt-4 max-w-xl text-base leading-relaxed text-surface-50/95">
+              <p className="text-balance text-pretty text-shadow-hero mt-4 max-w-xl text-base leading-relaxed text-surface-50/95 sm:text-lg">
                 Transform your experience into a story. Our AI analyzes, matches, and optimizes your resume.
               </p>
             </div>

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -383,36 +383,40 @@ export default function MainContent() {
   const handleExportPdf = useCallback(
     (variant) => {
       if (!resumeData?.plainText) {
-      pushToast({
-        type: "warning",
-        title: "Add your resume",
-        description: "Upload or paste your resume before exporting.",
-      });
-      return;
-    }
+        pushToast({
+          type: "warning",
+          title: "Add your resume",
+          description: "Upload or paste your resume before exporting.",
+        });
+        return;
+      }
 
-    try {
-      exportResumeToPdf({
-        resumeDocument: resumeData,
-        jobDescription,
-        matchAnalysis,
-        optimizations,
-        keywords: optimizationKeywords,
-        variant,
-      });
-      pushToast({
-        type: "success",
-        title: "Export ready",
-        description: "Use your browser dialog to save the PDF preview.",
-      });
-    } catch (error) {
-      pushToast({
-        type: "danger",
-        title: "Export blocked",
-        description: error?.message || "Enable pop-ups and try again.",
-      });
-    }
-  }, [jobDescription, matchAnalysis, optimizations, optimizationKeywords, pushToast, resumeData]);
+      const normalizedVariant = variant === "ats-plain" ? "ats-plain" : "styled";
+
+      try {
+        exportResumeToPdf({
+          resumeDocument: resumeData,
+          jobDescription,
+          matchAnalysis,
+          optimizations,
+          keywords: optimizationKeywords,
+          variant: normalizedVariant,
+        });
+        pushToast({
+          type: "success",
+          title: "Export ready",
+          description: "Use your browser dialog to save the PDF preview.",
+        });
+      } catch (error) {
+        pushToast({
+          type: "danger",
+          title: "Export blocked",
+          description: error?.message || "Enable pop-ups and try again.",
+        });
+      }
+    },
+    [jobDescription, matchAnalysis, optimizations, optimizationKeywords, pushToast, resumeData]
+  );
 
   const renderedToasts = useMemo(
     () =>
@@ -476,10 +480,10 @@ export default function MainContent() {
   return (
     <main
       data-app-main
-      className="relative z-10 -mt-16 min-h-screen pb-24 pt-20 sm:-mt-20 sm:pb-32 sm:pt-24 lg:pb-40"
+      className="relative z-10 -mt-12 min-h-screen pb-24 pt-16 sm:-mt-20 sm:pb-32 sm:pt-24 lg:-mt-28 lg:pb-40 lg:pt-28"
     >
       <ToastContainer>{renderedToasts}</ToastContainer>
-      <div className={`${containerClass} space-y-8 text-ink-700 sm:space-y-10 lg:space-y-12 dark:text-surface-50`}>
+      <div className={`${containerClass} space-y-7 text-ink-700 sm:space-y-10 lg:space-y-12 dark:text-surface-50`}>
         <div className="card-glow rounded-[var(--radius-card)] border border-secondary-500/12 bg-sand-50/95 p-6 shadow-card backdrop-blur-sm transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_24px_70px_-42px_rgba(15,15,18,0.58)] sm:p-8 sm:backdrop-blur-xl lg:p-9 dark:border-surface-50/12 dark:bg-zinc-900/60">
           {flowProgress > 0 && (
             <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-smoke-50/70 dark:bg-zinc-900/50">

--- a/src/features/Optimization.jsx
+++ b/src/features/Optimization.jsx
@@ -131,7 +131,7 @@ export default function Optimization({
             </SecondaryButton>
             <SecondaryButton
               icon={FileDown}
-              onClick={() => onExport?.("ats")}
+              onClick={() => onExport?.("ats-plain")}
               disabled={!canExport || isOptimizing}
               title={
                 !canExport
@@ -141,7 +141,7 @@ export default function Optimization({
                   : undefined
               }
             >
-              ATS PDF
+              ATS Plain
             </SecondaryButton>
             <SecondaryButton
               icon={Check}
@@ -215,7 +215,7 @@ export default function Optimization({
 
         <div className="relative space-y-4">
           {watermarkVisible && (
-            <div className="pointer-events-none absolute inset-0 z-10 grid place-items-center text-6xl font-black uppercase tracking-[0.6em] text-secondary-500/10">
+            <div className="pointer-events-none absolute inset-0 z-10 grid place-items-center px-6 text-center text-[2.75rem] font-black uppercase tracking-[0.45em] text-secondary-500/10 sm:px-0 sm:text-6xl sm:tracking-[0.6em]">
               Preview
             </div>
           )}

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -41,6 +41,7 @@ const applyThemeToDocument = (theme) => {
   if (typeof document === "undefined") return;
   const isDark = theme === "dark";
   document.documentElement.classList.toggle("dark", isDark);
+  document.documentElement.classList.toggle("light", !isDark);
   const value = isDark ? "dark" : "light";
   document.documentElement.dataset.theme = value;
   document.documentElement.setAttribute("data-theme", value);

--- a/src/hooks/useTheme.test.jsx
+++ b/src/hooks/useTheme.test.jsx
@@ -47,6 +47,7 @@ describe("useTheme", () => {
   beforeEach(() => {
     window.localStorage.clear();
     document.documentElement.classList.remove("dark");
+    document.documentElement.classList.remove("light");
     delete document.documentElement.dataset.theme;
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.style.colorScheme = "";
@@ -78,6 +79,7 @@ describe("useTheme", () => {
     expect(result.current.theme).toBe("dark");
     expect(result.current.isDark).toBe(true);
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
     expect(document.documentElement.dataset.theme).toBe("dark");
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     expect(document.documentElement.style.colorScheme).toBe("dark");
@@ -95,6 +97,7 @@ describe("useTheme", () => {
     expect(result.current.theme).toBe("dark");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
 
     act(() => {
@@ -104,6 +107,7 @@ describe("useTheme", () => {
     expect(result.current.theme).toBe("light");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
     expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(document.documentElement.classList.contains("light")).toBe(true);
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
   });
 
@@ -119,5 +123,6 @@ describe("useTheme", () => {
 
     expect(result.current.theme).toBe("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -16,25 +16,38 @@
     min-height: 100%;
   }
 
-  body {
-    font-family: var(--font-body);
+  html {
     background-color: #0b6b3a;
     background-image:
       radial-gradient(circle at 20% -10%, rgba(32, 201, 151, 0.28) 0%, rgba(3, 20, 13, 0) 65%),
       linear-gradient(135deg, #0b6b3a 0%, #146356 55%, #0c5335 100%);
     background-attachment: fixed, fixed;
     background-repeat: no-repeat;
-    background-size: 140% 140%, cover;
-    color: var(--color-ink-900);
+    background-size: 160% 160%, cover;
     transition: background-color var(--duration-breathe) var(--transition-snappy),
       background-image var(--duration-breathe) var(--transition-snappy);
   }
 
-  .dark body {
+  body {
+    font-family: var(--font-body);
+    color: var(--color-ink-900);
+    background: transparent;
+    overflow-x: hidden;
+  }
+
+  #root,
+  #app-root {
+    background: transparent;
+  }
+
+  .dark html {
     background-color: #0a3f26;
     background-image:
       radial-gradient(circle at 22% -12%, rgba(56, 189, 148, 0.24) 0%, rgba(6, 32, 24, 0) 68%),
       linear-gradient(135deg, #0a3f26 0%, #0b3a30 55%, #0c2e25 100%);
+  }
+
+  .dark body {
     color: var(--color-sand-50);
   }
 

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -8,7 +8,15 @@ describe("withVersion", () => {
     vi.unstubAllEnvs();
   });
 
-  it("appends a build id when provided", async () => {
+  it("prefers build timestamps when provided", async () => {
+    vi.stubEnv("VITE_BUILD_TIMESTAMP", "1727200000");
+    const { withVersion } = await loadModule();
+    expect(withVersion("https://example.com/hero.webp")).toBe(
+      "https://example.com/hero.webp?v=1727200000",
+    );
+  });
+
+  it("falls back to build ids when timestamps are missing", async () => {
     vi.stubEnv("VITE_BUILD_ID", "build-123");
     const { withVersion } = await loadModule();
     expect(withVersion("https://example.com/hero.webp")).toBe(
@@ -16,7 +24,7 @@ describe("withVersion", () => {
     );
   });
 
-  it("falls back to a dev tag when the id is missing", async () => {
+  it("falls back to a dev tag when no metadata is present", async () => {
     const { withVersion } = await loadModule();
     expect(withVersion("https://example.com/hero.webp")).toBe(
       "https://example.com/hero.webp?v=__dev__",
@@ -24,7 +32,7 @@ describe("withVersion", () => {
   });
 
   it("respects existing query params", async () => {
-    vi.stubEnv("VITE_BUILD_ID", "next");
+    vi.stubEnv("VITE_BUILD_TIMESTAMP", "next");
     const { withVersion } = await loadModule();
     expect(withVersion("https://example.com/hero.webp?quality=80")).toBe(
       "https://example.com/hero.webp?quality=80&v=next",
@@ -39,7 +47,7 @@ describe("skyline", () => {
   });
 
   it("always returns the Supabase skyline asset with cache busting", async () => {
-    vi.stubEnv("VITE_BUILD_ID", "20240924");
+    vi.stubEnv("VITE_BUILD_TIMESTAMP", "20240924");
     const { skyline } = await loadModule();
     expect(skyline()).toBe(
       "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp?v=20240924",

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,20 +1,27 @@
 const SKYLINE_URL =
   "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp";
 
-const readBuildId = () => {
-  const candidates: Array<string | undefined> = [];
-  const metaEnv = (import.meta as { env?: Record<string, unknown> }).env;
-  if (typeof metaEnv?.VITE_BUILD_ID === "string") {
-    candidates.push(metaEnv.VITE_BUILD_ID);
-  }
-  if (typeof process !== "undefined" && typeof process.env?.VITE_BUILD_ID === "string") {
-    candidates.push(process.env.VITE_BUILD_ID);
-  }
+const ENV_VERSION_KEYS = ["VITE_BUILD_TIMESTAMP", "VITE_BUILD_ID", "VITE_BUILD_TAG"] as const;
 
-  for (const candidate of candidates) {
-    const trimmed = candidate?.trim();
-    if (trimmed && trimmed.length > 0) {
-      return trimmed;
+const readBuildId = () => {
+  const metaEnv = (import.meta as { env?: Record<string, unknown> }).env ?? {};
+  const runtimeEnv = typeof process !== "undefined" ? process.env ?? {} : {};
+
+  for (const key of ENV_VERSION_KEYS) {
+    const metaValue = metaEnv[key];
+    if (typeof metaValue === "string") {
+      const trimmed = metaValue.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+
+    const runtimeValue = runtimeEnv[key];
+    if (typeof runtimeValue === "string") {
+      const trimmed = runtimeValue.trim();
+      if (trimmed) {
+        return trimmed;
+      }
     }
   }
 

--- a/src/services/exportPdf.js
+++ b/src/services/exportPdf.js
@@ -455,6 +455,13 @@ const triggerPrint = (html) => {
   }, 220);
 };
 
+const normalizeVariant = (variant = "styled") => {
+  if (variant === "ats" || variant === "ats-plain") {
+    return "ats-plain";
+  }
+  return "styled";
+};
+
 export const exportResumeToPdf = ({
   resumeDocument,
   resumeText = "",
@@ -465,9 +472,10 @@ export const exportResumeToPdf = ({
   variant = "styled",
 }) => {
   const payload = { resumeDocument, resumeText, jobDescription, matchAnalysis, optimizations, keywords };
-  const html = variant === "ats" ? buildPlainExportHtml(payload) : buildExportHtml(payload);
+  const normalizedVariant = normalizeVariant(variant);
+  const html = normalizedVariant === "ats-plain" ? buildPlainExportHtml(payload) : buildExportHtml(payload);
   triggerPrint(html);
   return true;
 };
 
-export { buildExportHtml, buildPlainExportHtml };
+export { buildExportHtml, buildPlainExportHtml, normalizeVariant };

--- a/src/services/exportPdf.test.js
+++ b/src/services/exportPdf.test.js
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { deriveResumeSections, buildExportHtml, buildPlainExportHtml, exportResumeToPdf } from "./exportPdf";
+import {
+  deriveResumeSections,
+  buildExportHtml,
+  buildPlainExportHtml,
+  exportResumeToPdf,
+  normalizeVariant,
+} from "./exportPdf";
 
 describe("exportPdf", () => {
   const sampleResume = `John Doe
@@ -66,6 +72,14 @@ Vision 2030 Dashboard – Built analytics portal for executive leadership.`;
     expect(html).toContain("ATS Resume Export");
     expect(html).toContain("Experience Highlights");
     expect(html).toContain("AI Suggestions");
+  });
+
+  it("normalizes export variant aliases", () => {
+    expect(normalizeVariant()).toBe("styled");
+    expect(normalizeVariant("styled")).toBe("styled");
+    expect(normalizeVariant("ats")).toBe("ats-plain");
+    expect(normalizeVariant("ats-plain")).toBe("ats-plain");
+    expect(normalizeVariant("unknown")).toBe("styled");
   });
 
   it("throws in non-browser environments", () => {


### PR DESCRIPTION
## Context
- eliminate visible seams by extending the Saudi-inspired gradient across the full page shell
- tighten hero/main spacing on mobile while keeping layout aligned with desktop design
- ensure hero art swaps bust caches quickly and expose an ATS-friendly export option

## Changes
- move the primary gradient to the html shell, hide horizontal overflow, and sync theme toggles to html classes
- adjust hero and workspace spacing for mobile breakpoints and rename the export CTA to include an ATS plain option
- normalize build timestamp cache busting for the skyline image and route `ats-plain` exports through the simplified template with updated tests

## Testing
- npm run lint
- npm run test
- npm run build

## Risks
- low: layout spacing refinements could surface edge cases on unusual viewport sizes

## Screenshots
- Not captured (headless environment)

------
https://chatgpt.com/codex/tasks/task_e_68d5653b9ad48330ac641ec627bfa15b