### PR TITLE
Fix skyline hero background and centralize asset URL

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -5,7 +5,7 @@ import SecondaryButton from "../ui/SecondaryButton";
 import { cn } from "../../lib/cn";
 import { useAuth } from "../../hooks/useAuth";
 import { useTheme } from "../../hooks/useTheme";
-import { skyline } from "../../lib/assets";
+import { getSkylineUrl } from "../../lib/assets";
 
 const saduPattern = encodeURIComponent(
   '<svg xmlns="http://www.w3.org/2000/svg" width="280" height="280" fill="none"><path d="M0 140h280" stroke="white" stroke-opacity="0.03"/><path d="M140 0v280" stroke="white" stroke-opacity="0.03"/><path d="M0 0l140 140L0 280" stroke="white" stroke-opacity="0.024"/><path d="M280 0L140 140l140 140" stroke="white" stroke-opacity="0.024"/><rect x="122" y="122" width="36" height="36" fill="white" fill-opacity="0.024"/><path d="M0 70h70L0 0z" fill="white" fill-opacity="0.02"/><path d="M280 70h-70L280 0z" fill="white" fill-opacity="0.02"/><path d="M0 210h70l-70 70z" fill="white" fill-opacity="0.02"/><path d="M280 210h-70l70 70z" fill="white" fill-opacity="0.02"/></svg>'
@@ -21,7 +21,14 @@ const containerClass = "app-shell w-full";
 export default function Header() {
   const { user, signInWithGoogle, signOut } = useAuth();
   const { theme, isDark, setTheme } = useTheme();
-  const skylineUrl = useMemo(() => skyline(), []);
+  const skylineUrl = useMemo(() => {
+    try {
+      return getSkylineUrl();
+    } catch (error) {
+      console.error("Failed to resolve skyline asset", error);
+      return "";
+    }
+  }, []);
   const [animateSkyline, setAnimateSkyline] = useState(false);
 
   useEffect(() => {
@@ -68,19 +75,16 @@ export default function Header() {
 
   return (
     <header
-      className="hero-bg-animate relative isolate flex min-h-screen min-h-[100svh] flex-col justify-between gap-8 overflow-hidden text-surface-50 pb-16 pt-12 sm:gap-12 sm:pb-24 sm:pt-20 md:min-h-[100dvh] lg:pb-28 lg:pt-24"
+      className="hero-bg-animate relative isolate flex min-h-[calc(100vh-96px)] min-h-[100svh] flex-col justify-between gap-8 overflow-hidden bg-cover bg-center bg-no-repeat text-surface-50 pb-16 pt-12 sm:gap-12 sm:pb-24 sm:pt-20 md:min-h-[100dvh] md:bg-[position:50%_35%] lg:pb-28 lg:pt-24"
     >
       {typeof skylineUrl === "string" && skylineUrl ? (
         <div
           aria-hidden="true"
           className={cn(
-            "bg-hero absolute inset-0 -z-40 pointer-events-none",
+            "bg-hero absolute inset-0 -z-40 min-h-[calc(100vh-96px)] pointer-events-none bg-scroll bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-700 md:bg-fixed md:bg-[position:50%_35%]",
             animateSkyline ? "skyline-once" : "skyline-still"
           )}
-          style={{
-            "--hero-skyline-image": `url('${skylineUrl}')`,
-            "--hero-skyline-offset": "calc(100% - clamp(200px, 34vh, 360px))",
-          }}
+          style={{ backgroundImage: `url('${skylineUrl}')` }}
         />
       ) : null}
       <div

--- a/src/index.css
+++ b/src/index.css
@@ -279,53 +279,22 @@
     }
   }
 
-  .skyline-once::before {
-    animation: skylineEntrance 1.6s ease-out forwards;
-  }
-
-  .skyline-still::before {
-    opacity: 0.88;
-  }
-
   .bg-hero {
     position: relative;
     pointer-events: none;
     overflow: hidden;
-    --hero-skyline-offset: calc(100% - clamp(220px, 32vh, 380px));
-    --hero-background-attachment: fixed;
-  }
-
-  .bg-hero::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-image: var(--hero-skyline-image);
-    background-attachment: var(--hero-background-attachment);
-    background-position: center var(--hero-skyline-offset);
-    background-repeat: no-repeat;
-    background-size: cover;
-    transform: scale(1.05);
     filter: saturate(1.05) brightness(0.96);
-    opacity: 0.84;
+    will-change: transform, opacity;
+    transform: translateY(0) scale(1);
   }
 
-  @media (max-width: 1024px) {
-    .bg-hero {
-      --hero-skyline-offset: calc(100% - clamp(200px, 30vh, 340px));
-    }
+  .skyline-once {
+    animation: skylineEntrance 1.6s ease-out forwards;
   }
 
-  @media (max-width: 768px) {
-    .bg-hero {
-      --hero-background-attachment: scroll;
-      --hero-skyline-offset: calc(100% - clamp(150px, 28vh, 280px));
-    }
-  }
-
-  @media (max-width: 480px) {
-    .bg-hero {
-      --hero-skyline-offset: calc(100% - clamp(120px, 34vh, 220px));
-    }
+  .skyline-still {
+    opacity: 0.88;
+    transform: translateY(0) scale(1);
   }
 
   @keyframes keywordChipShine {

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -40,24 +40,40 @@ describe("withVersion", () => {
   });
 });
 
-describe("skyline", () => {
+describe("getSkylineUrl", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.unstubAllEnvs();
+    vi.stubEnv("VITE_SUPABASE_URL", "https://cwcjeujextkwpmzdfzdz.supabase.co/");
   });
 
   it("always returns the Supabase skyline asset with cache busting", async () => {
     vi.stubEnv("VITE_BUILD_TIMESTAMP", "20240924");
-    const { skyline } = await loadModule();
-    expect(skyline()).toBe(
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const { getSkylineUrl } = await loadModule();
+    expect(getSkylineUrl()).toBe(
       "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp?v=20240924",
     );
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
   });
 
   it("defaults to the dev tag when build metadata is missing", async () => {
-    const { skyline } = await loadModule();
-    expect(skyline()).toBe(
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const { getSkylineUrl } = await loadModule();
+    expect(getSkylineUrl()).toBe(
       "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp?v=__dev__",
     );
+    consoleSpy.mockRestore();
+  });
+
+  it("never repeats the skyline filename in the resolved URL", async () => {
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const { getSkylineUrl } = await loadModule();
+    const url = getSkylineUrl();
+    consoleSpy.mockRestore();
+
+    expect(url).not.toContain("KAFDH.webp/KAFDH.webp");
+    expect(url.split("KAFDH.webp").length - 1).toBe(1);
   });
 });

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,6 +1,3 @@
-const SKYLINE_URL =
-  "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp";
-
 const ENV_VERSION_KEYS = ["VITE_BUILD_TIMESTAMP", "VITE_BUILD_ID", "VITE_BUILD_TAG"] as const;
 
 const readBuildId = () => {
@@ -38,4 +35,76 @@ export const withVersion = (url: string) => {
   return `${url}${separator}v=${version}`;
 };
 
-export const skyline = () => withVersion(SKYLINE_URL);
+const readEnvString = (key: string) => {
+  const metaEnv = (import.meta as { env?: Record<string, unknown> }).env ?? {};
+  const runtimeEnv = typeof process !== "undefined" ? process.env ?? {} : {};
+
+  const metaValue = metaEnv[key];
+  if (typeof metaValue === "string") {
+    const trimmed = metaValue.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  const runtimeValue = runtimeEnv[key];
+  if (typeof runtimeValue === "string") {
+    const trimmed = runtimeValue.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  return null;
+};
+
+const trimTrailingSlashes = (value: string) => value.replace(/\/+$/, "");
+
+const getSupabaseBaseUrl = () => {
+  const envValue = readEnvString("VITE_SUPABASE_URL");
+  if (!envValue) {
+    throw new Error(
+      "Missing VITE_SUPABASE_URL – required to resolve the skyline asset URL.",
+    );
+  }
+
+  return trimTrailingSlashes(envValue);
+};
+
+const SKYLINE_OBJECT_PATH = "storage/v1/object/public/ui-assets/KAFDH.webp";
+
+let memoizedSkylineUrl: string | null = null;
+let hasLoggedSkylineUrl = false;
+
+const isDevEnvironment = () => {
+  const metaEnv = (import.meta as { env?: Record<string, unknown> }).env ?? {};
+  if (typeof metaEnv.DEV === "boolean") {
+    return metaEnv.DEV;
+  }
+
+  const runtimeEnv = typeof process !== "undefined" ? process.env ?? {} : {};
+  if (typeof runtimeEnv.NODE_ENV === "string") {
+    return runtimeEnv.NODE_ENV !== "production";
+  }
+
+  return false;
+};
+
+export const getSkylineUrl = () => {
+  if (memoizedSkylineUrl) {
+    return memoizedSkylineUrl;
+  }
+
+  const baseUrl = getSupabaseBaseUrl();
+  const normalized = `${baseUrl}/${SKYLINE_OBJECT_PATH}`;
+  const versionedUrl = withVersion(normalized);
+
+  memoizedSkylineUrl = versionedUrl;
+
+  if (!hasLoggedSkylineUrl && isDevEnvironment()) {
+    console.info("[skylineUrl]", versionedUrl);
+    hasLoggedSkylineUrl = true;
+  }
+
+  return versionedUrl;
+};


### PR DESCRIPTION
## Summary
- centralize skyline asset resolution through `getSkylineUrl`, pulling from `VITE_SUPABASE_URL`, adding cache-busting and dev logging
- apply the new helper within the header hero, adjust background classes for a full-bleed skyline, and simplify supporting CSS
- extend unit tests to cover the new helper and prevent duplicate filename segments in the generated URL

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d589548b148330a212507581f634b3