### PR TITLE
Fix skyline hero background layout

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -12,6 +12,8 @@ const saduPattern = encodeURIComponent(
 );
 
 const containerClass = "app-shell w-full";
+const HERO_HEADER_OFFSET = "4.5rem";
+const heroMinHeightClass = "min-h-[calc(100vh-var(--hero-header-offset,4.5rem))]";
 
 export default function Header() {
   const { user, signInWithGoogle, signOut } = useAuth();
@@ -47,12 +49,18 @@ export default function Header() {
   const ThemeIcon = isDark ? Sun : Moon;
 
   return (
-    <header className="hero-bg-animate relative isolate overflow-hidden text-surface-50">
+    <header
+      className={cn(
+        "hero-bg-animate relative isolate overflow-hidden text-surface-50",
+        heroMinHeightClass,
+      )}
+      style={{ "--hero-header-offset": HERO_HEADER_OFFSET }}
+    >
       {typeof skylineUrl === "string" && skylineUrl ? (
         <div
           aria-hidden="true"
           className={cn(
-            "bg-hero absolute inset-x-0 top-0 -z-40 h-[140%] pointer-events-none bg-scroll bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-700 md:bg-fixed md:bg-[position:50%_35%]",
+            "bg-hero absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-700 md:bg-fixed md:bg-[position:50%_35%]",
             animateSkyline ? "skyline-once" : "skyline-still"
           )}
           style={{ backgroundImage: `url('${skylineUrl}')` }}
@@ -61,7 +69,7 @@ export default function Header() {
       <div
         aria-hidden="true"
         className={cn(
-          "absolute inset-x-0 top-0 -z-30 h-[150%] pointer-events-none transition-colors duration-700",
+          "absolute inset-0 -z-30 pointer-events-none transition-colors duration-700",
           isDark
             ? "bg-gradient-to-b from-black/50 via-emerald-900/40 to-emerald-950/60"
             : "bg-gradient-to-b from-emerald-700/40 via-transparent to-emerald-900/35",
@@ -70,13 +78,18 @@ export default function Header() {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(32,201,151,0.3)_0%,rgba(3,20,13,0)_70%)] mix-blend-screen" />
       </div>
       <div
-        className="absolute inset-x-0 top-0 -z-20 h-[150%] opacity-[0.08] mix-blend-soft-light"
+        className="absolute inset-0 -z-20 opacity-[0.08] mix-blend-soft-light"
         style={{ backgroundImage: `url("data:image/svg+xml,${saduPattern}")`, backgroundSize: "260px" }}
         aria-hidden="true"
       />
       <div className="accent-divider absolute inset-x-0 bottom-0 -z-10 h-px" aria-hidden="true" />
 
-      <div className="relative z-10 flex min-h-screen flex-col justify-between gap-8 pb-16 pt-12 sm:gap-12 sm:pb-24 sm:pt-20 lg:pb-28 lg:pt-24">
+      <div
+        className={cn(
+          "relative z-10 flex flex-col justify-between gap-8 pb-16 pt-12 sm:gap-12 sm:pb-24 sm:pt-20 lg:pb-28 lg:pt-24",
+          heroMinHeightClass,
+        )}
+      >
         <div className="border-b border-surface-50/10">
           <div className={`${containerClass} flex items-center justify-between gap-4 py-4 sm:py-6`}>
             <div className="flex items-center gap-3">

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -76,4 +76,16 @@ describe("getSkylineUrl", () => {
     expect(url).not.toContain("KAFDH.webp/KAFDH.webp");
     expect(url.split("KAFDH.webp").length - 1).toBe(1);
   });
+
+  it("normalizes redundant slashes between segments", async () => {
+    vi.stubEnv("VITE_SUPABASE_URL", "https://cwcjeujextkwpmzdfzdz.supabase.co////");
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const { getSkylineUrl } = await loadModule();
+    const url = getSkylineUrl();
+    consoleSpy.mockRestore();
+
+    expect(url).toBe(
+      "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp?v=__dev__",
+    );
+  });
 });

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -59,6 +59,19 @@ const readEnvString = (key: string) => {
 };
 
 const trimTrailingSlashes = (value: string) => value.replace(/\/+$/, "");
+const trimLeadingSlashes = (value: string) => value.replace(/^\/+/, "");
+
+const joinUrlSegments = (...segments: Array<string | null | undefined>) =>
+  segments
+    .filter((segment): segment is string => typeof segment === "string" && segment.length > 0)
+    .map((segment, index) => {
+      if (index === 0) {
+        return trimTrailingSlashes(segment);
+      }
+
+      return trimLeadingSlashes(trimTrailingSlashes(segment));
+    })
+    .join("/");
 
 const getSupabaseBaseUrl = () => {
   const envValue = readEnvString("VITE_SUPABASE_URL");
@@ -96,7 +109,7 @@ export const getSkylineUrl = () => {
   }
 
   const baseUrl = getSupabaseBaseUrl();
-  const normalized = `${baseUrl}/${SKYLINE_OBJECT_PATH}`;
+  const normalized = joinUrlSegments(baseUrl, SKYLINE_OBJECT_PATH);
   const versionedUrl = withVersion(normalized);
 
   memoizedSkylineUrl = versionedUrl;


### PR DESCRIPTION
## Summary
- harden skyline asset URL composition so Supabase paths are normalized without duplicate filename segments
- rework the hero header background styling to ensure the Riyadh skyline image renders full-bleed with correct positioning
- extend skyline asset tests to guard against redundant slash joins when resolving the public URL

## Testing
- npm run lint
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d59a42121c8330a87a8ad6ac136d99