### PR TITLE
Fix skyline asset URL validation and hero layout

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -51,42 +51,14 @@ export default function Header() {
   return (
     <header
       className={cn(
-        "hero-bg-animate relative isolate overflow-hidden text-surface-50",
+        "hero-bg-animate relative isolate flex flex-col overflow-hidden text-surface-50",
         heroMinHeightClass,
       )}
       style={{ "--hero-header-offset": HERO_HEADER_OFFSET }}
     >
-      {typeof skylineUrl === "string" && skylineUrl ? (
-        <div
-          aria-hidden="true"
-          className={cn(
-            "bg-hero absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-700 md:bg-fixed md:bg-[position:50%_35%]",
-            animateSkyline ? "skyline-once" : "skyline-still"
-          )}
-          style={{ backgroundImage: `url('${skylineUrl}')` }}
-        />
-      ) : null}
-      <div
-        aria-hidden="true"
-        className={cn(
-          "absolute inset-0 -z-30 pointer-events-none transition-colors duration-700",
-          isDark
-            ? "bg-gradient-to-b from-black/50 via-emerald-900/40 to-emerald-950/60"
-            : "bg-gradient-to-b from-emerald-700/40 via-transparent to-emerald-900/35",
-        )}
-      >
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(32,201,151,0.3)_0%,rgba(3,20,13,0)_70%)] mix-blend-screen" />
-      </div>
-      <div
-        className="absolute inset-0 -z-20 opacity-[0.08] mix-blend-soft-light"
-        style={{ backgroundImage: `url("data:image/svg+xml,${saduPattern}")`, backgroundSize: "260px" }}
-        aria-hidden="true"
-      />
-      <div className="accent-divider absolute inset-x-0 bottom-0 -z-10 h-px" aria-hidden="true" />
-
       <div
         className={cn(
-          "relative z-10 flex flex-col justify-between gap-8 pb-16 pt-12 sm:gap-12 sm:pb-24 sm:pt-20 lg:pb-28 lg:pt-24",
+          "relative z-10 flex flex-1 flex-col justify-between gap-8 pb-16 pt-12 sm:gap-12 sm:pb-24 sm:pt-20 lg:pb-28 lg:pt-24",
           heroMinHeightClass,
         )}
       >
@@ -208,6 +180,33 @@ export default function Header() {
           </div>
         </div>
       </div>
+      {typeof skylineUrl === "string" && skylineUrl ? (
+        <div
+          aria-hidden="true"
+          className={cn(
+            "bg-hero absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-700 md:bg-fixed md:bg-[position:50%_35%]",
+            animateSkyline ? "skyline-once" : "skyline-still"
+          )}
+          style={{ backgroundImage: `url('${skylineUrl}')` }}
+        />
+      ) : null}
+      <div
+        aria-hidden="true"
+        className={cn(
+          "absolute inset-0 -z-30 pointer-events-none transition-colors duration-700",
+          isDark
+            ? "bg-gradient-to-b from-black/50 via-emerald-900/40 to-emerald-950/60"
+            : "bg-gradient-to-b from-emerald-700/40 via-transparent to-emerald-900/35",
+        )}
+      >
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(32,201,151,0.3)_0%,rgba(3,20,13,0)_70%)] mix-blend-screen" />
+      </div>
+      <div
+        className="absolute inset-0 -z-20 opacity-[0.08] mix-blend-soft-light"
+        style={{ backgroundImage: `url("data:image/svg+xml,${saduPattern}")`, backgroundSize: "260px" }}
+        aria-hidden="true"
+      />
+      <div className="accent-divider absolute inset-x-0 bottom-0 -z-10 h-px" aria-hidden="true" />
     </header>
   );
 }

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -2,6 +2,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const loadModule = async () => import("./assets");
 
+describe("validatePublicUrl", () => {
+  it("rejects empty strings", async () => {
+    const { validatePublicUrl } = await loadModule();
+    expect(() => validatePublicUrl("")).toThrow(/cannot be empty/i);
+  });
+
+  it("normalizes redundant slashes in the pathname", async () => {
+    const { validatePublicUrl } = await loadModule();
+    expect(validatePublicUrl("https://example.com////foo//bar")).toBe(
+      "https://example.com/foo/bar",
+    );
+  });
+});
+
 describe("withVersion", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -47,45 +61,36 @@ describe("getSkylineUrl", () => {
     vi.stubEnv("VITE_SUPABASE_URL", "https://cwcjeujextkwpmzdfzdz.supabase.co/");
   });
 
-  it("always returns the Supabase skyline asset with cache busting", async () => {
+  it("returns a single segment URL for the skyline asset", async () => {
     vi.stubEnv("VITE_BUILD_TIMESTAMP", "20240924");
     const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const { getSkylineUrl } = await loadModule();
-    expect(getSkylineUrl()).toBe(
+    const url = getSkylineUrl();
+    expect(url).toBe(
       "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp?v=20240924",
     );
+    expect(url.split("KAFDH.webp").length - 1).toBe(1);
     expect(consoleSpy).toHaveBeenCalledTimes(1);
     consoleSpy.mockRestore();
   });
 
-  it("defaults to the dev tag when build metadata is missing", async () => {
-    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-    const { getSkylineUrl } = await loadModule();
-    expect(getSkylineUrl()).toBe(
-      "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp?v=__dev__",
+  it("rejects duplicates like .../KAFDH.webp/KAFDH.webp", async () => {
+    vi.stubEnv(
+      "VITE_SUPABASE_URL",
+      "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp/",
     );
-    consoleSpy.mockRestore();
-  });
-
-  it("never repeats the skyline filename in the resolved URL", async () => {
-    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const { getSkylineUrl } = await loadModule();
-    const url = getSkylineUrl();
-    consoleSpy.mockRestore();
-
-    expect(url).not.toContain("KAFDH.webp/KAFDH.webp");
-    expect(url.split("KAFDH.webp").length - 1).toBe(1);
+    expect(() => getSkylineUrl()).toThrow(/duplicated/i);
   });
 
-  it("normalizes redundant slashes between segments", async () => {
+  it("trims accidental double slashes", async () => {
     vi.stubEnv("VITE_SUPABASE_URL", "https://cwcjeujextkwpmzdfzdz.supabase.co////");
     const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const { getSkylineUrl } = await loadModule();
     const url = getSkylineUrl();
-    consoleSpy.mockRestore();
-
     expect(url).toBe(
       "https://cwcjeujextkwpmzdfzdz.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp?v=__dev__",
     );
+    consoleSpy.mockRestore();
   });
 });

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -59,7 +59,35 @@ const readEnvString = (key: string) => {
 };
 
 const trimTrailingSlashes = (value: string) => value.replace(/\/+$/, "");
-const trimLeadingSlashes = (value: string) => value.replace(/^\/+/, "");
+
+export const validatePublicUrl = (url: string) => {
+  if (typeof url !== "string") {
+    throw new TypeError("Public URL must be a string.");
+  }
+
+  const trimmed = url.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Public URL cannot be empty.");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid public URL: ${trimmed}`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Public URL must use http or https: ${parsed.href}`);
+  }
+
+  const normalizedPathname = parsed.pathname.replace(/\/{2,}/g, "/");
+  if (normalizedPathname !== parsed.pathname) {
+    parsed.pathname = normalizedPathname;
+  }
+
+  return parsed.toString();
+};
 
 const joinUrlSegments = (...segments: Array<string | null | undefined>) =>
   segments
@@ -69,7 +97,7 @@ const joinUrlSegments = (...segments: Array<string | null | undefined>) =>
         return trimTrailingSlashes(segment);
       }
 
-      return trimLeadingSlashes(trimTrailingSlashes(segment));
+      return trimTrailingSlashes(segment.replace(/^\/+/, ""));
     })
     .join("/");
 
@@ -81,10 +109,12 @@ const getSupabaseBaseUrl = () => {
     );
   }
 
-  return trimTrailingSlashes(envValue);
+  const validated = validatePublicUrl(envValue);
+  return trimTrailingSlashes(validated);
 };
 
 const SKYLINE_OBJECT_PATH = "storage/v1/object/public/ui-assets/KAFDH.webp";
+const SKYLINE_FILENAME = "KAFDH.webp";
 
 let memoizedSkylineUrl: string | null = null;
 let hasLoggedSkylineUrl = false;
@@ -110,7 +140,30 @@ export const getSkylineUrl = () => {
 
   const baseUrl = getSupabaseBaseUrl();
   const normalized = joinUrlSegments(baseUrl, SKYLINE_OBJECT_PATH);
-  const versionedUrl = withVersion(normalized);
+  const sanitizedUrlString = validatePublicUrl(normalized);
+  const sanitizedUrl = new URL(sanitizedUrlString);
+
+  const normalizedPath = sanitizedUrl.pathname.replace(/\/{2,}/g, "/");
+  if (normalizedPath !== sanitizedUrl.pathname) {
+    sanitizedUrl.pathname = normalizedPath;
+  }
+
+  const skylineOccurrences = normalizedPath
+    .split("/")
+    .filter(Boolean)
+    .filter((segment) => segment === SKYLINE_FILENAME).length;
+
+  if (skylineOccurrences === 0) {
+    throw new Error(`Skyline asset segment missing in resolved URL: ${sanitizedUrl.href}`);
+  }
+
+  if (skylineOccurrences > 1) {
+    throw new Error(
+      `Skyline asset segment duplicated in resolved URL: ${sanitizedUrl.href}`,
+    );
+  }
+
+  const versionedUrl = withVersion(sanitizedUrl.toString());
 
   memoizedSkylineUrl = versionedUrl;
 


### PR DESCRIPTION
## Summary
- add a `validatePublicUrl` helper and strengthen `getSkylineUrl` to normalize Supabase asset URLs and guard against duplicate skyline segments
- expand `src/lib/assets.test.ts` coverage to validate single-segment results, duplicate detection, and double-slash trimming
- update the hero header layout to rely on a flex-based wrapper so the skyline background reliably fills the viewport

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5c05e6e748330ae4989fd25153480