### PR TITLE
Fix resume upload flow and Supabase helpers

### DIFF
--- a/src/__tests__/ResumeUpload.test.jsx
+++ b/src/__tests__/ResumeUpload.test.jsx
@@ -1,41 +1,45 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 
-vi.mock('../services/supabase', () => ({
-  supabase: {
-    storage: {
-      from: () => ({
-        upload: vi.fn(),
-        getPublicUrl: vi.fn(() => ({ data: { publicUrl: '' } })),
-      }),
-    },
+const { MockAppError } = vi.hoisted(() => ({
+  MockAppError: class extends Error {
+    constructor({ code, message, hint }) {
+      super(message);
+      this.code = code;
+      this.hint = hint;
+    }
   },
 }));
 
-import ResumeUpload from '../features/ResumeUpload.jsx';
+vi.mock("../services/supabase.js", () => ({
+  AppError: MockAppError,
+  uploadResumeFile: vi.fn(),
+}));
 
-describe('ResumeUpload', () => {
-  it('renders the Saudi-inspired upload card', () => {
+import ResumeUpload from "../features/ResumeUpload.jsx";
+
+describe("ResumeUpload", () => {
+  it("renders the Saudi-inspired upload card", () => {
     render(<ResumeUpload onParseResume={vi.fn()} onToast={vi.fn()} />);
     expect(
-      screen.getByRole('heading', { name: /upload or paste your resume/i })
+      screen.getByRole("heading", { name: /upload or paste your resume/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /prepare resume/i })
+      screen.getByRole("button", { name: /prepare resume/i })
     ).toBeInTheDocument();
     expect(
       screen.getByText(/drop your resume here/i)
     ).toBeInTheDocument();
   });
 
-  it('prevents pasting PDF headers into the textarea', async () => {
+  it("prevents pasting PDF headers into the textarea", async () => {
     const onToast = vi.fn();
     render(<ResumeUpload onParseResume={vi.fn()} onToast={onToast} />);
 
     const textarea = screen.getByPlaceholderText(/paste resume text/i);
-    fireEvent.change(textarea, { target: { value: '%PDF-1.5' } });
+    fireEvent.change(textarea, { target: { value: "%PDF-1.5" } });
 
-    expect(textarea).toHaveValue('');
+    expect(textarea).toHaveValue("");
     expect(screen.getByText(/this looks like a pdf — use upload\./i)).toBeInTheDocument();
     expect(onToast).toHaveBeenCalled();
   });

--- a/src/__tests__/UploadCard.test.jsx
+++ b/src/__tests__/UploadCard.test.jsx
@@ -1,8 +1,24 @@
-import { render, screen } from '@testing-library/react';
-import UploadCard from '../components/ui/UploadCard.jsx';
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
 
-describe('UploadCard', () => {
-  it('matches snapshot and exposes accessible controls', () => {
+const { MockAppError } = vi.hoisted(() => ({
+  MockAppError: class extends Error {
+    constructor({ code, message, hint }) {
+      super(message);
+      this.code = code;
+      this.hint = hint;
+    }
+  },
+}));
+
+vi.mock("../services/supabase.js", () => ({
+  AppError: MockAppError,
+}));
+
+import UploadCard from "../components/ui/UploadCard.jsx";
+
+describe("UploadCard", () => {
+  it("matches snapshot and exposes accessible controls", () => {
     const { container } = render(
       <UploadCard
         fileName=""

--- a/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
+++ b/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
@@ -115,7 +115,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
       </p>
     </div>
     <input
-      accept=".pdf,.docx"
+      accept=".pdf,.docx,.txt"
       aria-label="Upload resume file"
       class="sr-only"
       title="Upload resume file"

--- a/src/__tests__/supabase.test.js
+++ b/src/__tests__/supabase.test.js
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { uploadSpy, authMock, storageMock } = vi.hoisted(() => {
+  const uploadFn = vi.fn();
+  const auth = { getUser: vi.fn() };
+  const storage = { from: vi.fn(() => ({ upload: uploadFn })) };
+  return { uploadSpy: uploadFn, authMock: auth, storageMock: storage };
+});
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({
+    auth: authMock,
+    storage: storageMock,
+  })),
+}));
+
+import { cleanBaseName, uploadResumeFile } from "../services/supabase.js";
+
+describe("supabase upload service", () => {
+  beforeEach(() => {
+    uploadSpy.mockReset();
+    authMock.getUser.mockReset();
+    storageMock.from.mockClear();
+  });
+
+  it("sanitizes file names while preserving extensions", () => {
+    expect(cleanBaseName(" Senior Resume .PDF ")).toBe("senior-resume.pdf");
+    expect(cleanBaseName("résumé final.docx")).toBe("r-sum-final.docx");
+    expect(cleanBaseName("resume")).toBe("resume.pdf");
+  });
+
+  it("appends version suffix when storage reports a conflict", async () => {
+    authMock.getUser.mockResolvedValue({ data: { user: { id: "user-123" } }, error: null });
+    uploadSpy
+      .mockImplementationOnce(async () => ({ error: { statusCode: 409 } }))
+      .mockImplementationOnce(async (_path, _file, options) => {
+        options?.onUploadProgress?.({ loaded: 5, total: 10 });
+        return { error: null };
+      });
+
+    const progressSpy = vi.fn();
+    const result = await uploadResumeFile({ name: "Resume.PDF" }, { onProgress: progressSpy });
+
+    expect(storageMock.from).toHaveBeenCalledWith("resumes");
+    expect(uploadSpy).toHaveBeenCalledTimes(2);
+    expect(uploadSpy.mock.calls[0][0]).toBe("user-123/resume.pdf");
+    expect(uploadSpy.mock.calls[1][0]).toBe("user-123/resume-v2.pdf");
+    expect(result).toEqual({ path: "user-123/resume-v2.pdf", fileName: "resume-v2.pdf", userId: "user-123" });
+    expect(progressSpy).toHaveBeenCalledWith({ loaded: 5, total: 10 });
+  });
+
+  it("throws an AppError when the user is not authenticated", async () => {
+    authMock.getUser.mockResolvedValue({ data: { user: null }, error: null });
+    await expect(uploadResumeFile({ name: "resume.pdf" })).rejects.toMatchObject({
+      code: "auth/unauthenticated",
+    });
+  });
+
+  it("wraps storage failures in an AppError", async () => {
+    authMock.getUser.mockResolvedValue({ data: { user: { id: "user-123" } }, error: null });
+    uploadSpy.mockResolvedValueOnce({ error: { statusCode: 500 } });
+
+    await expect(uploadResumeFile({ name: "resume.pdf" })).rejects.toMatchObject({
+      code: "upload/storage-failure",
+    });
+  });
+});

--- a/src/components/ui/UploadCard.jsx
+++ b/src/components/ui/UploadCard.jsx
@@ -1,8 +1,17 @@
 import { useRef, useState } from "react";
 import { ClipboardPenLine, FileText, UploadCloud, XCircle } from "lucide-react";
+import { AppError } from "../../services/supabase.js";
 import { cn } from "../../lib/cn";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
+
+const ACCEPTED_MIME_TYPES = new Set([
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "text/plain",
+]);
+
+const MAX_SIZE_BYTES = 5 * 1024 * 1024;
 
 const statusCopy = {
   uploading: "Uploading resume…",
@@ -23,15 +32,62 @@ export default function UploadCard({
   error,
   disabled = false,
   textHelper = "",
+  onValidationError,
 }) {
   const inputRef = useRef(null);
   const [isDragging, setIsDragging] = useState(false);
+
+  const handleFile = async (file) => {
+    if (!file) return;
+
+    if (!ACCEPTED_MIME_TYPES.has(file.type)) {
+      onValidationError?.(
+        new AppError({
+          code: "file/unsupported-type",
+          message: "Only PDF, DOCX, or TXT resumes are supported.",
+          hint: "Upload a PDF or DOCX, or paste plain text.",
+        })
+      );
+      return;
+    }
+
+    if (file.size > MAX_SIZE_BYTES) {
+      onValidationError?.(
+        new AppError({
+          code: "file/too-large",
+          message: "File must be 5MB or smaller.",
+          hint: "Compress the resume and try again.",
+        })
+      );
+      return;
+    }
+
+    if (file.type === "text/plain") {
+      try {
+        const text = await file.text();
+        onTextChange?.(text);
+      } catch {
+        onValidationError?.(
+          new AppError({
+            code: "file/read-failed",
+            message: "We couldn't read that text file.",
+            hint: "Paste the contents manually instead.",
+          })
+        );
+      }
+      return;
+    }
+
+    onFileSelect?.(file);
+  };
 
   const handleDrop = (event) => {
     event.preventDefault();
     setIsDragging(false);
     const file = event.dataTransfer.files?.[0];
-    if (file) onFileSelect?.(file);
+    if (file) {
+      void handleFile(file);
+    }
   };
 
   const handleDragOver = (event) => {
@@ -46,7 +102,12 @@ export default function UploadCard({
 
   const handleFileChange = (event) => {
     const file = event.target.files?.[0];
-    if (file) onFileSelect?.(file);
+    if (file) {
+      void handleFile(file);
+    }
+    if (event.target) {
+      event.target.value = "";
+    }
   };
 
   const stateMessage = statusCopy[status];
@@ -105,7 +166,7 @@ export default function UploadCard({
       <input
         ref={inputRef}
         type="file"
-        accept=".pdf,.docx"
+        accept=".pdf,.docx,.txt"
         className="sr-only"
         aria-label="Upload resume file"
         title="Upload resume file"

--- a/src/features/ResumeUpload.jsx
+++ b/src/features/ResumeUpload.jsx
@@ -1,14 +1,44 @@
 import { useCallback, useEffect, useState } from "react";
 import UploadCard from "../components/ui/UploadCard.jsx";
-import { supabase } from "../services/supabase";
+import { AppError, uploadResumeFile } from "../services/supabase.js";
 
-const ACCEPTED_TYPES = [
+const ACCEPTED_TYPES = new Set([
   "application/pdf",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-];
+]);
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 const PDF_HELPER_MESSAGE = "This looks like a PDF — use Upload.";
+const ERROR_MESSAGES = {
+  "file/unsupported-type": {
+    type: "warning",
+    title: "Unsupported file",
+  },
+  "file/too-large": {
+    type: "warning",
+    title: "File too large",
+  },
+  "file/read-failed": {
+    type: "danger",
+    title: "Paste failed",
+  },
+  "auth/unauthenticated": {
+    type: "warning",
+    title: "Sign in to upload",
+  },
+  "auth/user-fetch-failed": {
+    type: "danger",
+    title: "Session check failed",
+  },
+  "upload/storage-failure": {
+    type: "danger",
+    title: "Upload failed",
+  },
+  "upload/name-conflict": {
+    type: "danger",
+    title: "Rename and retry",
+  },
+};
 
 export default function ResumeUpload({ onParseResume, resumeDocument, onToast }) {
   const [file, setFile] = useState(null);
@@ -17,6 +47,23 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState("");
   const [textWarning, setTextWarning] = useState("");
+
+  const showErrorToast = useCallback(
+    (appError, fallbackType = "danger") => {
+      if (!appError) return;
+      const copy = ERROR_MESSAGES[appError.code] || {
+        type: fallbackType,
+        title: "Something went wrong",
+      };
+      setError(appError.message);
+      onToast?.({
+        type: copy.type,
+        title: copy.title,
+        description: appError.hint ? `${appError.message} ${appError.hint}` : appError.message,
+      });
+    },
+    [onToast]
+  );
 
   useEffect(() => {
     if (resumeDocument?.plainText && !textValue) {
@@ -50,38 +97,53 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
       if (textWarning) {
         setTextWarning("");
       }
+      if (file) {
+        setFile(null);
+      }
       setTextValue(value);
     },
-    [onToast, textWarning]
+    [file, onToast, textWarning]
+  );
+
+  const handleValidationError = useCallback(
+    (validationError) => {
+      const appError =
+        validationError instanceof AppError
+          ? validationError
+          : new AppError(validationError);
+      showErrorToast(appError, "warning");
+    },
+    [showErrorToast]
   );
 
   const handleFileSelect = useCallback(
     (selectedFile) => {
       if (!selectedFile) return;
-      if (!ACCEPTED_TYPES.includes(selectedFile.type)) {
-        const message = "Only PDF or DOCX files are supported.";
-        setError(message);
-        onToast?.({
-          type: "warning",
-          title: "Unsupported file",
-          description: message,
-        });
+      if (!ACCEPTED_TYPES.has(selectedFile.type)) {
+        handleValidationError(
+          new AppError({
+            code: "file/unsupported-type",
+            message: "Only PDF or DOCX files are supported.",
+            hint: "Upload a PDF or DOCX resume.",
+          })
+        );
         return;
       }
       if (selectedFile.size > MAX_BYTES) {
-        const message = "File must be 5MB or smaller.";
-        setError(message);
-        onToast?.({
-          type: "warning",
-          title: "File too large",
-          description: message,
-        });
+        handleValidationError(
+          new AppError({
+            code: "file/too-large",
+            message: "File must be 5MB or smaller.",
+            hint: "Compress the resume and try again.",
+          })
+        );
         return;
       }
+      setTextWarning("");
       setError("");
       setFile(selectedFile);
     },
-    [onToast]
+    [handleValidationError]
   );
 
   const handleSubmit = useCallback(async () => {
@@ -114,49 +176,15 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
 
       if (file) {
         setStatus("uploading");
-        const extension = file.name.split(".").pop() || "pdf";
-        const baseName = file.name.replace(/\.[^.]+$/, "");
-        const sanitizedBase = baseName.replace(/[^a-z0-9]/gi, "-").toLowerCase();
-        const fileName = `${Date.now()}-${sanitizedBase}.${extension}`;
+        await uploadResumeFile(file, {
+          onProgress: ({ loaded, total }) => {
+            if (!total) return;
+            const percent = Math.round((loaded / total) * 60);
+            setProgress(Math.max(5, percent));
+          },
+        });
 
-        const {
-          data: { user },
-          error: userError,
-        } = await supabase.auth.getUser();
-
-        if (userError) {
-          throw userError;
-        }
-
-        if (!user) {
-          throw new Error("You must be signed in to upload a resume.");
-        }
-
-        const filePath = `${user.id}/${fileName}`;
-
-        const { error: uploadError } = await supabase.storage
-          .from("resumes")
-          .upload(filePath, file, {
-            cacheControl: "3600",
-            upsert: false,
-            onUploadProgress: ({ loaded, total }) => {
-              if (!total) return;
-              const percent = Math.round((loaded / total) * 60);
-              setProgress(percent);
-            },
-          });
-
-        if (uploadError) {
-          throw uploadError;
-        }
-        // private bucket => signed URL
-        const { error: signedErr } = await supabase.storage
-          .from("resumes")
-          .createSignedUrl(filePath, 60 * 60);
-
-        if (signedErr) throw signedErr;
-
-        setProgress(70);
+        setProgress((prev) => Math.max(prev, 70));
         onToast?.({
           type: "success",
           title: "File uploaded",
@@ -178,17 +206,18 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
         setProgress(0);
       }, 900);
     } catch (submissionError) {
-      const message =
-        submissionError?.message || "We could not prepare your resume.";
       setStatus("error");
-      setError(message);
-      onToast?.({
-        type: "danger",
-        title: "Upload failed",
-        description: message,
-      });
+      const appError =
+        submissionError instanceof AppError
+          ? submissionError
+          : new AppError({
+              code: "upload/storage-failure",
+              message: submissionError?.message || "We could not prepare your resume.",
+              hint: "Try again shortly.",
+            });
+      showErrorToast(appError);
     }
-  }, [file, onParseResume, onToast, textValue]);
+  }, [file, onParseResume, onToast, showErrorToast, textValue]);
 
   return (
     <div className="space-y-6">
@@ -207,6 +236,7 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
         error={error}
         disabled={status === "uploading" || status === "parsing"}
         textHelper={textWarning}
+        onValidationError={handleValidationError}
       />
     </div>
   );

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -1,7 +1,104 @@
 // src/services/supabase.js
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const { VITE_SUPABASE_URL: supabaseUrl, VITE_SUPABASE_ANON_KEY: supabaseAnonKey } =
+  import.meta.env ?? {};
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export class AppError extends Error {
+  constructor({ code, message, hint }) {
+    super(message);
+    this.name = "AppError";
+    this.code = code;
+    this.hint = hint;
+  }
+}
+
+export const cleanBaseName = (fileName) => {
+  if (!fileName) {
+    return "resume.pdf";
+  }
+  const trimmed = fileName.trim();
+  const extensionMatch = trimmed.match(/\.([^.\s]{1,10})$/i);
+  const extension = extensionMatch ? `.${extensionMatch[1].toLowerCase()}` : "";
+  const base = trimmed.replace(/\.[^.]+$/, "").toLowerCase();
+  const slug = base.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const safeBase = slug || "resume";
+  return `${safeBase}${extension || ".pdf"}`;
+};
+
+const buildVersionedName = (baseName, attempt) => {
+  if (attempt === 0) return baseName;
+  const version = attempt + 1;
+  const extensionIndex = baseName.lastIndexOf(".");
+  if (extensionIndex === -1) {
+    return `${baseName}-v${version}`;
+  }
+  const namePart = baseName.slice(0, extensionIndex);
+  const extension = baseName.slice(extensionIndex);
+  return `${namePart}-v${version}${extension}`;
+};
+
+export const uploadResumeFile = async (file, { onProgress } = {}) => {
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError) {
+    throw new AppError({
+      code: "auth/user-fetch-failed",
+      message: "We couldn't verify your session.",
+      hint: "Refresh and sign in again.",
+    });
+  }
+
+  if (!user) {
+    throw new AppError({
+      code: "auth/unauthenticated",
+      message: "Sign in to upload.",
+      hint: "Log in to store your resume securely.",
+    });
+  }
+
+  const baseName = cleanBaseName(file?.name || "");
+  const bucket = supabase.storage.from("resumes");
+  const maxAttempts = 5;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const candidateName = buildVersionedName(baseName, attempt);
+    const path = `${user.id}/${candidateName}`;
+
+    const { error } = await bucket.upload(path, file, {
+      cacheControl: "3600",
+      upsert: false,
+      onUploadProgress: (progressEvent) => {
+        if (typeof onProgress === "function") {
+          onProgress(progressEvent);
+        }
+      },
+    });
+
+    if (!error) {
+      return { path, fileName: candidateName, userId: user.id };
+    }
+
+    const status = error?.statusCode ?? error?.status;
+    if (status === 409) {
+      continue;
+    }
+
+    throw new AppError({
+      code: "upload/storage-failure",
+      message: "We couldn't store your resume.",
+      hint: "Please try again.",
+    });
+  }
+
+  throw new AppError({
+    code: "upload/name-conflict",
+    message: "We couldn't store your resume.",
+    hint: "Rename the file and try again.",
+  });
+};


### PR DESCRIPTION
## Summary
- enforce resume file validation in UploadCard and route plain text files to the paste workflow
- refactor ResumeUpload to surface AppError-driven toasts and wire progress to the Supabase upload helper
- add Supabase storage utilities for RLS-compliant paths plus regression tests for conflicts and clean filenames

## Testing
- npm ci *(fails: 403 Forbidden fetching eslint)*
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5c53d565c8330a12b4caa46733ea7