### PR TITLE
Fix skyline background loading and fallback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,6 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100%;
+  min-height: 100%;
 }
 
 .logo {

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -148,6 +148,13 @@ export default function Header() {
   const nextThemeLabel = isDark ? "Switch to light theme" : "Switch to dark theme";
   const ThemeIcon = isDark ? Sun : Moon;
 
+  const skeletonBackgroundClass = cn(
+    "absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-opacity duration-700",
+    isDark
+      ? "bg-gradient-to-b from-emerald-950/40 via-emerald-900/30 to-emerald-950/60"
+      : "bg-gradient-to-b from-emerald-200/45 via-emerald-100/35 to-emerald-50/20",
+  );
+
   return (
     <header
       className={cn(
@@ -351,14 +358,9 @@ export default function Header() {
       {/* Skyline background image with loading state */}
       {typeof skylineUrl === "string" && skylineUrl ? (
         <>
-          {/* Skeleton loader while image loads */}
           {!skylineLoaded && (
-            <div
-              aria-hidden="true"
-              className="absolute inset-0 -z-40 pointer-events-none bg-gradient-to-b from-emerald-900/20 via-emerald-800/10 to-transparent animate-pulse"
-            />
+            <div aria-hidden="true" className={skeletonBackgroundClass} />
           )}
-          {/* Actual skyline image */}
           <div
             aria-hidden="true"
             className={cn(
@@ -369,7 +371,9 @@ export default function Header() {
             style={{ backgroundImage: `url('${skylineUrl}')` }}
           />
         </>
-      ) : null}
+      ) : (
+        <div aria-hidden="true" className={skeletonBackgroundClass} />
+      )}
       <div
         aria-hidden="true"
         className={cn(

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -107,7 +107,7 @@ describe("getSkylineUrl", () => {
 
   it("returns a single segment URL for the skyline asset", async () => {
     vi.stubEnv("VITE_BUILD_TIMESTAMP", "20240924");
-    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const { getSkylineUrl } = await loadModule();
     const url = getSkylineUrl();
     expect(url).toBe(
@@ -148,7 +148,7 @@ describe("getSkylineUrl", () => {
 
   it("trims accidental double slashes", async () => {
     vi.stubEnv("VITE_SUPABASE_URL", "https://cwcjeujextkwpmzdfzdz.supabase.co////");
-    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const { getSkylineUrl } = await loadModule();
     const url = getSkylineUrl();
     expect(url).toBe(
@@ -161,7 +161,7 @@ describe("getSkylineUrl", () => {
     vi.stubEnv("VITE_ASSETS_BASE_URL", "https://cdn.example.com");
     vi.stubEnv("VITE_SUPABASE_URL", "https://cwcjeujextkwpmzdfzdz.supabase.co");
     vi.stubEnv("VITE_BUILD_TIMESTAMP", "20240925");
-    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const { getSkylineUrl } = await loadModule();
     const url = getSkylineUrl();
     expect(url).toBe(
@@ -174,7 +174,7 @@ describe("getSkylineUrl", () => {
   it("falls back to VITE_SUPABASE_URL when VITE_ASSETS_BASE_URL is not set", async () => {
     vi.stubEnv("VITE_SUPABASE_URL", "https://cwcjeujextkwpmzdfzdz.supabase.co");
     vi.stubEnv("VITE_BUILD_TIMESTAMP", "20240926");
-    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const { getSkylineUrl } = await loadModule();
     const url = getSkylineUrl();
     expect(url).toBe(

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -151,12 +151,6 @@ const getSupabaseBaseUrl = () => {
 const SKYLINE_OBJECT_PATH = "storage/v1/object/public/ui-assets/KAFDH.webp";
 const SKYLINE_FILENAME = "KAFDH.webp";
 
-const hasDuplicateFilename = (pathname: string, file: string) => {
-  const re = new RegExp(`/${file}(?=(/|$))`, "g");
-  const matches = pathname.match(re);
-  return Array.isArray(matches) && matches.length > 1;
-};
-
 const toProjectBase = (baseUrl: string) => {
   const url = new URL(baseUrl);
   return url.origin;
@@ -262,14 +256,28 @@ const buildSkylineObjectUrl = (baseUrl: string) => {
     sanitizedUrl.pathname = normalizedPath;
   }
 
-  if (!normalizedPath.endsWith(`/${SKYLINE_FILENAME}`)) {
+  const pathSegments = sanitizedUrl.pathname.split("/");
+  let filenameCount = 0;
+  const dedupedSegments = pathSegments.filter((segment) => {
+    if (segment === SKYLINE_FILENAME) {
+      filenameCount += 1;
+      if (filenameCount > 1) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  if (filenameCount === 0) {
     throw new Error(`Skyline asset segment missing in resolved URL: ${sanitizedUrl.href}`);
   }
 
-  if (hasDuplicateFilename(normalizedPath, SKYLINE_FILENAME)) {
-    throw new Error(
-      `Skyline asset segment duplicated in resolved URL: ${sanitizedUrl.href}`,
-    );
+  if (dedupedSegments.length !== pathSegments.length) {
+    sanitizedUrl.pathname = dedupedSegments.join("/") || "/";
+  }
+
+  if (!sanitizedUrl.pathname.endsWith(`/${SKYLINE_FILENAME}`)) {
+    throw new Error(`Skyline asset segment missing in resolved URL: ${sanitizedUrl.href}`);
   }
 
   return sanitizedUrl.toString();
@@ -289,7 +297,7 @@ export const getSkylineUrl = () => {
   memoizedSkylineUrl = versionedUrl;
 
   if (!hasLoggedSkylineUrl && isDevEnvironment()) {
-    console.info("[skylineUrl]", versionedUrl);
+    console.log("[skylineUrl]", versionedUrl);
     hasLoggedSkylineUrl = true;
   }
 


### PR DESCRIPTION
## Summary
- prevent duplicate skyline filenames when resolving Supabase asset URLs and log the resolved path with console.log
- add a theme-aware skeleton fallback for the hero skyline background and allow the hero wrapper to span the full viewport width

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dff76ea4208330a9ec7f7c0d612c9d