### PR TITLE
Fix skyline asset host validation and fallbacks

### DIFF
--- a/src/__tests__/Header.test.jsx
+++ b/src/__tests__/Header.test.jsx
@@ -1,0 +1,86 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import Header from "../components/Layout/Header.jsx";
+
+vi.mock("../hooks/useAuth", () => ({
+  useAuth: () => ({
+    user: null,
+    signInWithGoogle: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useTheme", () => ({
+  useTheme: () => ["light", vi.fn()],
+}));
+
+vi.mock("../lib/assets", () => ({
+  getSkylineUrl: vi.fn(() => ""),
+}));
+
+const createMatchMedia = () => {
+  const listeners = new Set();
+  return (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: (_event, listener) => {
+      if (typeof listener === "function") {
+        listeners.add(listener);
+      }
+    },
+    removeEventListener: (_event, listener) => {
+      if (typeof listener === "function") {
+        listeners.delete(listener);
+      }
+    },
+    addListener: (listener) => {
+      if (typeof listener === "function") {
+        listeners.add(listener);
+      }
+    },
+    removeListener: (listener) => {
+      if (typeof listener === "function") {
+        listeners.delete(listener);
+      }
+    },
+    dispatchEvent: (event) => {
+      listeners.forEach((listener) => listener(event));
+      return true;
+    },
+  });
+};
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: createMatchMedia(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Header", () => {
+  it("keeps the gradient fallback when the skyline URL is empty", () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { container } = render(<Header />);
+
+    expect(container.querySelector(".bg-hero")).toBeNull();
+
+    const fallback = Array.from(container.querySelectorAll('[aria-hidden="true"]')).find((element) =>
+      element.className.includes("bg-gradient-to-b"),
+    );
+
+    expect(fallback).toBeDefined();
+
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+});
+

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -104,20 +104,39 @@ describe("publicAssetUrl", () => {
   });
 
   it("builds a single well-formed public asset URL", async () => {
-    vi.stubEnv("VITE_ASSETS_BASE_URL", "https://cdn.example.com");
+    vi.stubEnv("VITE_ASSETS_BASE_URL", "https://cdn.example.com/");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { publicAssetUrl } = await loadModule();
     expect(publicAssetUrl("ui-assets", "/hero//KAFDH.webp")).toBe(
       "https://cdn.example.com/storage/v1/object/public/ui-assets/hero/KAFDH.webp",
     );
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
-  it("rejects when the environment contains a full object URL", async () => {
+  it("coerces pathful base URLs to the origin and warns in dev", async () => {
     vi.stubEnv(
-      "VITE_SUPABASE_URL",
+      "VITE_ASSETS_BASE_URL",
+      "https://project.supabase.co/storage/v1/object/public/ui-assets",
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { publicAssetUrl } = await loadModule();
+    expect(publicAssetUrl("ui-assets", "KAFDH.webp")).toBe(
       "https://project.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp",
     );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("VITE_ASSETS_BASE_URL should be host-only"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("falls back to an empty string when neither env is valid", async () => {
+    vi.stubEnv("VITE_ASSETS_BASE_URL", "");
+    vi.stubEnv("VITE_SUPABASE_URL", "");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { publicAssetUrl } = await loadModule();
-    expect(() => publicAssetUrl("ui-assets", "KAFDH.webp")).toThrow(/host-only url/i);
+    expect(publicAssetUrl("ui-assets", "KAFDH.webp")).toBe("");
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -100,6 +100,27 @@ export const validatePublicUrl = (url: string) => {
   return parsed.toString();
 };
 
+const HOST_ONLY_PATTERN = /^https?:\/\/[^/]+$/i;
+
+const isDevEnvironment = () => {
+  const metaEnv = (import.meta as { env?: Record<string, unknown> }).env;
+  if (metaEnv && typeof metaEnv.DEV === "boolean") {
+    return metaEnv.DEV;
+  }
+
+  if (typeof process !== "undefined" && typeof process.env?.NODE_ENV === "string") {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  return false;
+};
+
+const warnHostOnlyEnv = (message: string) => {
+  if (isDevEnvironment()) {
+    console.warn(message);
+  }
+};
+
 const ensureHostOnlyUrl = (value: string, sourceKey: string) => {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -117,28 +138,47 @@ const ensureHostOnlyUrl = (value: string, sourceKey: string) => {
     throw new Error(`${sourceKey} must use http or https.`);
   }
 
-  const hasPath = parsed.pathname && parsed.pathname !== "/";
-  if (hasPath || parsed.search || parsed.hash) {
-    throw new Error(`${sourceKey} must be a host-only URL (https://host.tld).`);
+  const origin = parsed.origin;
+  const trailingSlashNormalized = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+  const isAlreadyHostOnly = HOST_ONLY_PATTERN.test(trimmed) || trailingSlashNormalized === origin;
+
+  const hasNonRootPath = parsed.pathname && parsed.pathname !== "/" && parsed.pathname !== "";
+  const hasQueryOrHash = (parsed.search && parsed.search !== "") || (parsed.hash && parsed.hash !== "");
+
+  if (!isAlreadyHostOnly || hasNonRootPath || hasQueryOrHash) {
+    warnHostOnlyEnv(
+      `[assets] ${sourceKey} should be host-only (https://host.tld). Using ${origin} instead of ${trimmed}.`,
+    );
   }
 
-  return parsed.origin;
+  return origin;
 };
 
 const readAssetsBaseHost = () => {
+  const warnInvalidEnv = (key: string, error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    warnHostOnlyEnv(`[assets] ${key} is invalid: ${message}`);
+  };
+
   const assetsBase = readEnvString("VITE_ASSETS_BASE_URL");
   if (assetsBase) {
-    return ensureHostOnlyUrl(assetsBase, "VITE_ASSETS_BASE_URL");
+    try {
+      return ensureHostOnlyUrl(assetsBase, "VITE_ASSETS_BASE_URL");
+    } catch (error) {
+      warnInvalidEnv("VITE_ASSETS_BASE_URL", error);
+    }
   }
 
   const supabaseUrl = readEnvString("VITE_SUPABASE_URL");
   if (supabaseUrl) {
-    return ensureHostOnlyUrl(supabaseUrl, "VITE_SUPABASE_URL");
+    try {
+      return ensureHostOnlyUrl(supabaseUrl, "VITE_SUPABASE_URL");
+    } catch (error) {
+      warnInvalidEnv("VITE_SUPABASE_URL", error);
+    }
   }
 
-  throw new Error(
-    "Missing VITE_ASSETS_BASE_URL or VITE_SUPABASE_URL – required to resolve the skyline asset URL.",
-  );
+  return null;
 };
 
 const normalizeBucketName = (bucket: string) => {
@@ -185,6 +225,9 @@ const PUBLIC_STORAGE_PREFIX = "/storage/v1/object/public";
 
 export const publicAssetUrl = (bucket: string, objectPath: string) => {
   const baseHost = readAssetsBaseHost();
+  if (!baseHost) {
+    return "";
+  }
   const bucketSegment = normalizeBucketName(bucket);
   const objectSegment = normalizeObjectPath(objectPath);
   const pathname = `${PUBLIC_STORAGE_PREFIX}/${bucketSegment}/${objectSegment}`;
@@ -198,7 +241,17 @@ let memoizedSkylineUrl: string | null = null;
 
 export const getSkylineUrl = () => {
   if (!memoizedSkylineUrl) {
-    memoizedSkylineUrl = withVersion(publicAssetUrl(SKYLINE_BUCKET, SKYLINE_OBJECT_PATH));
+    try {
+      const resolvedUrl = publicAssetUrl(SKYLINE_BUCKET, SKYLINE_OBJECT_PATH);
+      memoizedSkylineUrl = resolvedUrl ? withVersion(resolvedUrl) : "";
+    } catch (error) {
+      warnHostOnlyEnv(
+        `[assets] Failed to resolve skyline asset: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      memoizedSkylineUrl = "";
+    }
   }
 
   return memoizedSkylineUrl;


### PR DESCRIPTION
## Summary
- normalize Supabase asset host envs to origins with dev-only warnings and graceful fallbacks when missing
- keep skyline URL building deterministic while returning an empty string when no valid host is available
- add tests covering host coercion, missing env behavior, and the hero gradient fallback when the skyline asset is unavailable

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e17398516c8330aeb34ffe8b7655db