### PR TITLE
Harden resume uploads for Supabase storage

### DIFF
--- a/src/__tests__/ResumeUpload.test.jsx
+++ b/src/__tests__/ResumeUpload.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 
 const { MockAppError } = vi.hoisted(() => ({
@@ -17,8 +17,13 @@ vi.mock("../services/supabase.js", () => ({
 }));
 
 import ResumeUpload from "../features/ResumeUpload.jsx";
+import { uploadResumeFile } from "../services/supabase.js";
 
 describe("ResumeUpload", () => {
+  beforeEach(() => {
+    uploadResumeFile.mockReset();
+  });
+
   it("renders the Saudi-inspired upload card", () => {
     render(<ResumeUpload onParseResume={vi.fn()} onToast={vi.fn()} />);
     expect(
@@ -42,5 +47,67 @@ describe("ResumeUpload", () => {
     expect(textarea).toHaveValue("");
     expect(screen.getByText(/this looks like a pdf — use upload\./i)).toBeInTheDocument();
     expect(onToast).toHaveBeenCalled();
+  });
+
+  it("uploads PDFs and shows a success toast", async () => {
+    const onToast = vi.fn();
+    const onParseResume = vi.fn().mockResolvedValue({});
+    uploadResumeFile.mockResolvedValueOnce({ path: "user-123/resume.pdf" });
+
+    render(<ResumeUpload onParseResume={onParseResume} onToast={onToast} />);
+
+    const fileInput = screen
+      .getAllByLabelText(/upload resume file/i)
+      .find((element) => element.tagName === "INPUT");
+    if (!(fileInput instanceof HTMLInputElement)) {
+      throw new Error("Hidden file input not found");
+    }
+    const file = new File(["resume"], "resume.pdf", { type: "application/pdf" });
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    const submitButton = screen.getByRole("button", { name: /prepare resume/i });
+
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    expect(uploadResumeFile).toHaveBeenCalledWith(file, expect.any(Object));
+    expect(onParseResume).toHaveBeenCalledWith(file);
+    expect(onToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "success",
+        title: expect.stringMatching(/file uploaded/i),
+      })
+    );
+  });
+
+  it("rejects files over 5MB with a warning toast", async () => {
+    const onToast = vi.fn();
+    render(<ResumeUpload onParseResume={vi.fn()} onToast={onToast} />);
+
+    const fileInput = screen
+      .getAllByLabelText(/upload resume file/i)
+      .find((element) => element.tagName === "INPUT");
+    if (!(fileInput instanceof HTMLInputElement)) {
+      throw new Error("Hidden file input not found");
+    }
+    const file = new File(["a"], "large.pdf", { type: "application/pdf" });
+    Object.defineProperty(file, "size", { value: 5 * 1024 * 1024 + 1, configurable: true });
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    expect(uploadResumeFile).not.toHaveBeenCalled();
+    expect(onToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "warning",
+        title: expect.stringMatching(/file too large/i),
+      })
+    );
+    expect(screen.getByText(/file must be 5mb or smaller\./i)).toBeInTheDocument();
   });
 });

--- a/src/__tests__/supabase.test.js
+++ b/src/__tests__/supabase.test.js
@@ -45,9 +45,24 @@ describe("supabase upload service", () => {
     expect(uploadSpy).toHaveBeenCalledTimes(2);
     expect(uploadSpy.mock.calls[0][0]).toBe("user-123/resume.pdf");
     expect(uploadSpy.mock.calls[1][0]).toBe("user-123/resume-v2.pdf");
-    expect(uploadSpy.mock.calls[0][2]).toMatchObject({ contentType: "application/octet-stream" });
+    expect(uploadSpy.mock.calls[0][2]).toMatchObject({ contentType: "application/pdf" });
     expect(result).toEqual({ path: "user-123/resume-v2.pdf", fileName: "resume-v2.pdf", userId: "user-123" });
     expect(progressSpy).toHaveBeenCalledWith({ loaded: 5, total: 10 });
+  });
+
+  it("uploads successfully when storage accepts the first attempt", async () => {
+    authMock.getUser.mockResolvedValue({ data: { user: { id: "user-456" } }, error: null });
+    uploadSpy.mockResolvedValueOnce({ error: null });
+
+    const file = { name: "resume.docx", type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", size: 1024 };
+    const result = await uploadResumeFile(file);
+
+    expect(uploadSpy).toHaveBeenCalledWith(
+      "user-456/resume.docx",
+      file,
+      expect.objectContaining({ contentType: file.type, upsert: false })
+    );
+    expect(result).toEqual({ path: "user-456/resume.docx", fileName: "resume.docx", userId: "user-456" });
   });
 
   it("uses the file content type when provided", async () => {
@@ -69,6 +84,17 @@ describe("supabase upload service", () => {
     await expect(uploadResumeFile({ name: "resume.pdf" })).rejects.toMatchObject({
       code: "auth/unauthenticated",
     });
+  });
+
+  it("rejects files larger than 5MB", async () => {
+    const largeSize = 5 * 1024 * 1024 + 1;
+    const file = { name: "resume.pdf", type: "application/pdf", size: largeSize };
+
+    await expect(uploadResumeFile(file)).rejects.toMatchObject({
+      code: "file/too-large",
+    });
+    expect(authMock.getUser).not.toHaveBeenCalled();
+    expect(uploadSpy).not.toHaveBeenCalled();
   });
 
   it("wraps storage failures in an AppError", async () => {

--- a/src/components/ui/UploadCard.jsx
+++ b/src/components/ui/UploadCard.jsx
@@ -5,13 +5,43 @@ import { cn } from "../../lib/cn";
 import PrimaryButton from "./PrimaryButton";
 import SecondaryButton from "./SecondaryButton";
 
-const ACCEPTED_MIME_TYPES = new Set([
+const DOCUMENT_MIME_TYPES = new Set([
   "application/pdf",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-  "text/plain",
 ]);
 
+const DOCUMENT_EXTENSIONS = new Set(["pdf", "docx"]);
+
+const TEXT_MIME_TYPES = new Set(["text/plain"]);
+const TEXT_EXTENSIONS = new Set(["txt"]);
+
 const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+
+const getExtension = (fileName) => {
+  if (typeof fileName !== "string") return "";
+  const match = fileName.match(/\.([^.]+)$/);
+  return match ? match[1].toLowerCase() : "";
+};
+
+const isDocumentFile = (file) => {
+  if (!file) return false;
+  const normalizedType = typeof file.type === "string" ? file.type.toLowerCase() : "";
+  if (DOCUMENT_MIME_TYPES.has(normalizedType)) {
+    return true;
+  }
+  const extension = getExtension(file.name);
+  return DOCUMENT_EXTENSIONS.has(extension);
+};
+
+const isPlainTextFile = (file) => {
+  if (!file) return false;
+  const normalizedType = typeof file.type === "string" ? file.type.toLowerCase() : "";
+  if (TEXT_MIME_TYPES.has(normalizedType)) {
+    return true;
+  }
+  const extension = getExtension(file.name);
+  return TEXT_EXTENSIONS.has(extension);
+};
 
 const statusCopy = {
   uploading: "Uploading resume…",
@@ -40,7 +70,11 @@ export default function UploadCard({
   const handleFile = async (file) => {
     if (!file) return;
 
-    if (!ACCEPTED_MIME_TYPES.has(file.type)) {
+    const size = typeof file.size === "number" ? file.size : 0;
+    const documentFile = isDocumentFile(file);
+    const plainTextFile = isPlainTextFile(file);
+
+    if (!documentFile && !plainTextFile) {
       onValidationError?.(
         new AppError({
           code: "file/unsupported-type",
@@ -51,7 +85,7 @@ export default function UploadCard({
       return;
     }
 
-    if (file.size > MAX_SIZE_BYTES) {
+    if (size > MAX_SIZE_BYTES) {
       onValidationError?.(
         new AppError({
           code: "file/too-large",
@@ -62,7 +96,7 @@ export default function UploadCard({
       return;
     }
 
-    if (file.type === "text/plain") {
+    if (plainTextFile) {
       try {
         const text = await file.text();
         onTextChange?.(text);

--- a/src/features/ResumeUpload.jsx
+++ b/src/features/ResumeUpload.jsx
@@ -2,10 +2,12 @@ import { useCallback, useEffect, useState } from "react";
 import UploadCard from "../components/ui/UploadCard.jsx";
 import { AppError, uploadResumeFile } from "../services/supabase.js";
 
-const ACCEPTED_TYPES = new Set([
+const DOCUMENT_MIME_TYPES = new Set([
   "application/pdf",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 ]);
+
+const DOCUMENT_EXTENSIONS = new Set(["pdf", "docx"]);
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 const PDF_HELPER_MESSAGE = "This looks like a PDF — use Upload.";
@@ -50,6 +52,24 @@ const ERROR_MESSAGES = {
     type: "danger",
     title: "Upload not allowed",
   },
+};
+
+const getExtension = (fileName) => {
+  if (typeof fileName !== "string") {
+    return "";
+  }
+  const match = fileName.match(/\.([^.]+)$/);
+  return match ? match[1].toLowerCase() : "";
+};
+
+const isDocumentFile = (file) => {
+  if (!file) return false;
+  const normalizedType = typeof file.type === "string" ? file.type.toLowerCase() : "";
+  if (DOCUMENT_MIME_TYPES.has(normalizedType)) {
+    return true;
+  }
+  const extension = getExtension(file.name);
+  return DOCUMENT_EXTENSIONS.has(extension);
 };
 
 export default function ResumeUpload({ onParseResume, resumeDocument, onToast }) {
@@ -131,7 +151,7 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
   const handleFileSelect = useCallback(
     (selectedFile) => {
       if (!selectedFile) return;
-      if (!ACCEPTED_TYPES.has(selectedFile.type)) {
+      if (!isDocumentFile(selectedFile)) {
         handleValidationError(
           new AppError({
             code: "file/unsupported-type",
@@ -141,7 +161,8 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
         );
         return;
       }
-      if (selectedFile.size > MAX_BYTES) {
+      const size = typeof selectedFile.size === "number" ? selectedFile.size : 0;
+      if (size > MAX_BYTES) {
         handleValidationError(
           new AppError({
             code: "file/too-large",

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -40,7 +40,67 @@ const buildVersionedName = (baseName, attempt) => {
   return `${namePart}-v${version}${extension}`;
 };
 
+const DOCUMENT_MIME_TYPES = new Set([
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+]);
+
+const DOCUMENT_EXTENSIONS = new Map([
+  ["pdf", "application/pdf"],
+  ["docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+]);
+
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+const getExtension = (fileName) => {
+  if (typeof fileName !== "string") {
+    return "";
+  }
+  const match = fileName.match(/\.([^.]+)$/);
+  return match ? match[1].toLowerCase() : "";
+};
+
+const resolveContentType = (file) => {
+  const type = typeof file?.type === "string" ? file.type.toLowerCase() : "";
+  if (DOCUMENT_MIME_TYPES.has(type)) {
+    return type;
+  }
+  const extension = getExtension(file?.name);
+  return DOCUMENT_EXTENSIONS.get(extension) ?? "application/octet-stream";
+};
+
+const ensureSupportedDocument = (file) => {
+  if (!file || typeof file.name !== "string") {
+    throw new AppError({
+      code: "file/unsupported-type",
+      message: "Only PDF or DOCX files are supported.",
+      hint: "Upload a PDF or DOCX resume.",
+    });
+  }
+
+  const extension = getExtension(file.name);
+  const type = typeof file.type === "string" ? file.type.toLowerCase() : "";
+  if (!DOCUMENT_MIME_TYPES.has(type) && !DOCUMENT_EXTENSIONS.has(extension)) {
+    throw new AppError({
+      code: "file/unsupported-type",
+      message: "Only PDF or DOCX files are supported.",
+      hint: "Upload a PDF or DOCX resume.",
+    });
+  }
+
+  const size = Number.isFinite(file.size) ? file.size : 0;
+  if (size > MAX_UPLOAD_BYTES) {
+    throw new AppError({
+      code: "file/too-large",
+      message: "File must be 5MB or smaller.",
+      hint: "Compress the resume and try again.",
+    });
+  }
+};
+
 export const uploadResumeFile = async (file, { onProgress } = {}) => {
+  ensureSupportedDocument(file);
+
   const {
     data: { user },
     error: userError,
@@ -65,7 +125,7 @@ export const uploadResumeFile = async (file, { onProgress } = {}) => {
   const baseName = cleanBaseName(file?.name || "");
   const bucket = supabase.storage.from("resumes");
   const maxAttempts = 5;
-  const contentType = typeof file?.type === "string" && file.type.length > 0 ? file.type : "application/octet-stream";
+  const contentType = resolveContentType(file);
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     const candidateName = buildVersionedName(baseName, attempt);


### PR DESCRIPTION
## Summary
- tighten the upload card and resume feature to classify PDF/DOCX files versus plain text, enforce the 5MB limit, and surface user toasts accordingly
- harden the Supabase upload service with file-type validation, derived content types, and conflict-safe storage paths
- expand unit tests to cover happy-path uploads, oversize rejections, unauthenticated users, and conflict suffixing

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1a7e98ff48330a1ea26dba5e67427