### PR TITLE
Polish Saudi theme visuals

### DIFF
--- a/src/__tests__/Header.test.jsx
+++ b/src/__tests__/Header.test.jsx
@@ -74,7 +74,7 @@ describe("Header", () => {
     expect(container.querySelector(".bg-hero")).toBeNull();
 
     const fallback = Array.from(container.querySelectorAll('[aria-hidden="true"]')).find((element) =>
-      element.className.includes("bg-gradient-to-b"),
+      element.className.includes("bg-[radial-gradient"),
     );
 
     expect(fallback).toBeDefined();

--- a/src/__tests__/PrimaryButton.test.jsx
+++ b/src/__tests__/PrimaryButton.test.jsx
@@ -3,12 +3,12 @@ import { describe, it, expect } from 'vitest';
 import PrimaryButton from '../components/ui/PrimaryButton.jsx';
 
 describe('PrimaryButton', () => {
-  it('exposes the gold shimmer animation on hover and focus-visible', () => {
+  it('applies the gradient, focus ring, and elevation tokens', () => {
     render(<PrimaryButton>Call to Action</PrimaryButton>);
 
     const button = screen.getByRole('button', { name: 'Call to Action' });
-    expect(button.className).toContain('focus-visible:ring-[color:var(--accent)]');
-    expect(button.className).toContain('motion-safe:hover:before:animate-[accent-shimmer_1.4s_linear]');
-    expect(button.className).toContain('motion-reduce:hover:before:animate-none');
+    expect(button.className).toContain('bg-[var(--button-primary-gradient)]');
+    expect(button.className).toContain('focus-visible:ring-[color:var(--button-primary-focus)]');
+    expect(button.className).toContain('shadow-[var(--button-primary-shadow)]');
   });
 });

--- a/src/__tests__/SectionTitle.test.jsx
+++ b/src/__tests__/SectionTitle.test.jsx
@@ -3,18 +3,19 @@ import { describe, it, expect } from 'vitest';
 import SectionTitle from '../components/ui/SectionTitle.jsx';
 
 describe('SectionTitle', () => {
-  it('applies the gold shimmer styles to the heading container', () => {
+  it('applies the new panel stroke styling to the heading container', () => {
     render(<SectionTitle eyebrow="Insights" title="Experience" description="Detail" />);
 
     const wrapper = screen.getByRole('heading', { name: 'Experience', level: 2 }).parentElement;
     expect(wrapper).toHaveClass('group/section-title');
+    expect(wrapper.className).toContain('border-[color:var(--panel-stroke)]');
   });
 
-  it('uses the shimmer animation utility classes on the heading', () => {
+  it('exposes the tightened typography rhythm on the heading', () => {
     render(<SectionTitle eyebrow="Insights" title="Experience" />);
 
     const heading = screen.getByRole('heading', { name: 'Experience', level: 2 });
-    expect(heading.className).toContain('motion-safe:group-hover/section-title:after:animate-[accent-shimmer_1.6s_linear]');
-    expect(heading.className).toContain('motion-reduce:group-hover/section-title:after:animate-none');
+    expect(heading.className).toContain('tracking-tight');
+    expect(heading.className).toContain('text-[color:var(--ink)]');
   });
 });

--- a/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
+++ b/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
 <div>
   <section
     aria-live="polite"
-    class="space-y-6 rounded-[var(--radius-card)] border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_48%)] bg-[color:var(--panel-bg)] p-8 text-[color:var(--ink)] shadow-[0_32px_88px_-48px_color-mix(in_oklab,var(--emerald-900),transparent_68%)] backdrop-blur-xl dark:text-[color:var(--surface)]"
+    class="space-y-6 rounded-[var(--radius-card)] border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] p-8 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]"
   >
     <div
       class="space-y-2 text-left"
@@ -27,17 +27,17 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
     </div>
     <div
       aria-label="Upload resume file"
-      class="relative flex flex-col items-center justify-center gap-3 rounded-[calc(var(--radius-card)_-_0.5rem)] border border-dashed border-[color:color-mix(in_oklab,var(--accent),transparent_48%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_4%)] px-6 py-12 text-center shadow-[0_28px_72px_-44px_color-mix(in_oklab,var(--emerald-900),transparent_62%)] backdrop-blur-xl transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_30%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
+      class="relative flex flex-col items-center justify-center gap-3 rounded-[calc(var(--radius-card)_-_0.5rem)] border border-dashed border-[color:color-mix(in_oklab,var(--accent),transparent_36%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_6%)] px-6 py-12 text-center shadow-[var(--shadow-soft)] transition-[border-color,box-shadow,transform,background-color] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_26%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
       role="button"
       tabindex="0"
     >
       <span
-        class="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_50%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_6%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)] shadow-[0_12px_32px_-24px_color-mix(in_oklab,var(--emerald-900),transparent_70%)]"
+        class="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]"
       >
         Max 5MB
       </span>
       <div
-        class="flex items-center gap-2 rounded-full border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_42%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] px-4 py-2 text-xs font-semibold text-[color:var(--ink)] shadow-[0_20px_48px_-34px_color-mix(in_oklab,var(--emerald-900),transparent_66%)] dark:text-[color:var(--surface)]"
+        class="flex items-center gap-2 rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-2 text-xs font-semibold text-[color:var(--ink)] shadow-[var(--shadow-soft)] dark:text-[color:var(--surface)]"
       >
         <svg
           aria-hidden="true"
@@ -163,7 +163,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
         Paste resume text instead
       </span>
       <textarea
-        class="min-h-[160px] w-full resize-y rounded-2xl border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_46%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_16%)] px-4 py-3 text-sm leading-relaxed text-[color:var(--ink)] shadow-[inset_0_1px_0_color-mix(in_oklab,var(--panel-highlight),transparent_25%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_30%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:text-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
+        class="min-h-[160px] w-full resize-y rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] px-4 py-3 text-sm leading-relaxed text-[color:var(--ink)] shadow-[inset_0_1px_0_color-mix(in_oklab,var(--panel-highlight),transparent_22%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:text-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
         placeholder="Paste resume text…"
       />
     </label>
@@ -171,16 +171,16 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
       class="flex flex-wrap items-center gap-3"
     >
       <button
-        class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-[color:color-mix(in_oklab,var(--accent),transparent_42%)] bg-[radial-gradient(circle_at_20%_-20%,color-mix(in_oklab,var(--surface),transparent_75%)_0%,transparent_55%),color-mix(in_oklab,var(--accent),transparent_35%)] text-[color:var(--surface)] shadow-[0_26px_70px_-38px_color-mix(in_oklab,var(--accent),transparent_48%)] backdrop-blur-xl hover:-translate-y-0.5 hover:shadow-[0_38px_92px_-40px_color-mix(in_oklab,var(--accent),transparent_40%)] focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-[color:var(--bg)] dark:focus-visible:ring-offset-[color:var(--surface)] before:pointer-events-none before:absolute before:inset-[1px] before:rounded-[calc(var(--radius-card)_/_1.8)] before:bg-[linear-gradient(120deg,transparent_0%,color-mix(in_oklab,var(--accent-gold),transparent_55%)_35%,var(--accent-gold)_55%,transparent_100%)] before:bg-[length:220%_100%] before:opacity-0 before:transition-opacity before:duration-[var(--duration-snappy)] before:ease-[var(--transition-snappy)] before:content-[''] hover:before:opacity-100 focus-visible:before:opacity-100 motion-safe:hover:before:animate-[accent-shimmer_1.4s_linear] motion-safe:focus-visible:before:animate-[accent-shimmer_1.4s_linear] motion-reduce:hover:before:animate-none motion-reduce:focus-visible:before:animate-none after:pointer-events-none after:absolute after:inset-[2px] after:rounded-[calc(var(--radius-card)_/_1.9)] after:border after:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_34%)] after:opacity-75 after:content-[''] disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:color-mix(in_oklab,var(--accent),transparent_70%)] disabled:bg-[color-mix(in_oklab,var(--accent),transparent_68%)] disabled:text-[color:color-mix(in_oklab,var(--surface),transparent_35%)] disabled:shadow-none disabled:before:hidden disabled:after:hidden"
+        class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-white transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-transparent bg-[var(--button-primary-gradient)] shadow-[var(--button-primary-shadow)] hover:-translate-y-0.5 hover:shadow-[var(--button-primary-shadow-strong)] focus-visible:ring-[color:var(--button-primary-focus)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)] disabled:translate-y-0 disabled:cursor-not-allowed disabled:bg-[color-mix(in_oklab,var(--surface),transparent_16%)] disabled:text-[color:color-mix(in_oklab,var(--ink),transparent_54%)] disabled:shadow-none"
       >
         <span
-          class="relative z-10 tracking-wide"
+          class="relative z-10"
         >
           Prepare Resume
         </span>
       </button>
       <button
-        class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_46%)] bg-[color:var(--panel-bg)] text-[color:var(--ink)] shadow-[0_24px_64px_-40px_color-mix(in_oklab,var(--emerald-900),transparent_66%)] backdrop-blur-xl hover:-translate-y-0.5 hover:shadow-[0_32px_86px_-42px_color-mix(in_oklab,var(--emerald-900),transparent_52%)] hover:text-[color:var(--ink)] focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_26%)] focus-visible:ring-offset-[color:var(--bg)] dark:focus-visible:ring-offset-[color:var(--surface)] before:pointer-events-none before:absolute before:inset-[1px] before:rounded-[calc(var(--radius-card)_/_2.1)] before:bg-[linear-gradient(180deg,color-mix(in_oklab,var(--panel-highlight),transparent_35%)_0%,transparent_72%)] before:opacity-0 before:transition before:duration-500 before:ease-out before:content-[''] hover:before:opacity-100 after:pointer-events-none after:absolute after:inset-[2px] after:rounded-[calc(var(--radius-card)_/_2.2)] after:border after:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_58%)] after:opacity-70 after:content-[''] disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_58%)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_24%)] disabled:shadow-none disabled:before:hidden disabled:after:hidden"
+        class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-[color:var(--ink)] transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] shadow-[var(--shadow-soft)] hover:-translate-y-0.5 hover:shadow-[var(--shadow-lift)] hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)] disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_30%)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_32%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_18%)] disabled:shadow-none"
         disabled=""
       >
         <svg
@@ -209,7 +209,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
           />
         </svg>
         <span
-          class="relative z-10 tracking-wide"
+          class="relative z-10"
         >
           Clear inputs
         </span>

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -140,19 +140,19 @@ export default function Header() {
   }, []);
 
   const themeButtonClass = cn(
-    "inline-flex h-10 w-10 items-center justify-center rounded-full border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+    "inline-flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
     isDark
-      ? "border-surface-50/25 bg-surface-900/70 text-surface-50/90 shadow-[0_18px_46px_-30px_rgba(0,0,0,0.6)] hover:text-accent-200 focus-visible:ring-accent-300/70 focus-visible:ring-offset-surface-900"
-      : "border-sand-200/60 bg-surface-50/95 text-ink-600 shadow-[0_18px_48px_-28px_rgba(9,91,50,0.42)] hover:text-primary-600 focus-visible:ring-accent-300/80 focus-visible:ring-offset-sand-50"
+      ? "bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] text-[color:var(--surface)] shadow-[var(--shadow-soft)] hover:text-[color:var(--accent)] focus-visible:ring-[color:var(--button-primary-focus)] focus-visible:ring-offset-[color:var(--surface-strong)]"
+      : "bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_6%)] text-[color:var(--ink)] shadow-[var(--shadow-soft)] hover:text-[color:var(--accent)] focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_24%)] focus-visible:ring-offset-[color:var(--surface)]"
   );
   const nextThemeLabel = isDark ? "Switch to light theme" : "Switch to dark theme";
   const ThemeIcon = isDark ? Sun : Moon;
 
   const skeletonBackgroundClass = cn(
-    "absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-opacity duration-700",
+    "absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-opacity duration-300",
     isDark
-      ? "bg-gradient-to-b from-emerald-950/40 via-emerald-900/30 to-emerald-950/60"
-      : "bg-gradient-to-b from-emerald-200/45 via-emerald-100/35 to-emerald-50/20",
+      ? "bg-[radial-gradient(circle_at_20%_10%,color-mix(in_oklab,var(--surface-strong),transparent_50%)_0%,transparent_65%),linear-gradient(to_bottom,color-mix(in_oklab,var(--surface-strong),transparent_35%)_0%,color-mix(in_oklab,var(--surface),transparent_70%)_100%)]"
+      : "bg-[radial-gradient(circle_at_18%_12%,color-mix(in_oklab,var(--surface-strong),transparent_28%)_0%,transparent_62%),linear-gradient(to_bottom,color-mix(in_oklab,var(--surface),transparent_20%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_65%)_100%)]"
   );
 
   return (
@@ -169,10 +169,10 @@ export default function Header() {
           heroMinHeightClass,
         )}
       >
-        <div className="border-b border-surface-50/10">
+        <div className="border-b border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_38%)]">
           <div className={`${containerClass} flex items-center justify-between gap-4 py-4 sm:py-6`}>
             <div className="flex items-center gap-3">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-surface-50/10 text-accent-500 shadow-soft">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] text-[color:var(--accent)] shadow-[var(--shadow-soft)]">
                 <Sparkles className="h-5 w-5" aria-hidden="true" />
               </span>
               <div>
@@ -201,11 +201,7 @@ export default function Header() {
                   Sign Out
                 </SecondaryButton>
               ) : (
-                <PrimaryButton
-                  icon={LogIn}
-                  onClick={signInWithGoogle}
-                  className="from-primary-600 via-primary-600 to-primary-700 shadow-lg"
-                >
+                <PrimaryButton icon={LogIn} onClick={signInWithGoogle}>
                   Sign In
                 </PrimaryButton>
               )}
@@ -221,7 +217,7 @@ export default function Header() {
               "space-y-6 sm:space-y-7 transform-gpu",
               prefersReducedMotion
                 ? "opacity-100"
-                : "transition-[opacity,transform] duration-[600ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
+                : "transition-[opacity,transform] duration-[280ms] ease-[var(--transition-snappy)]",
               heroVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
             )}
           >
@@ -231,27 +227,27 @@ export default function Header() {
             >
               Designed for Saudi ambition
             </span>
-            <div className="relative max-w-2xl rounded-[var(--radius-card)] border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_46%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] p-6 shadow-[0_28px_70px_-44px_color-mix(in_oklab,var(--emerald-900),transparent_60%)] backdrop-blur-xl sm:p-7 lg:p-8">
+            <div className="relative max-w-2xl rounded-[var(--radius-card)] border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] p-6 text-[color:var(--surface)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] sm:p-7 lg:p-8">
               <span
                 aria-hidden="true"
                 className="absolute -top-8 left-6 text-accent-400 drop-shadow-[0_0_12px_rgba(197,166,106,0.35)]"
               >
                 <Sparkles className="h-7 w-7" />
               </span>
-              <h1 className="text-balance text-shadow-hero text-4xl font-bold leading-tight tracking-tight sm:text-5xl lg:text-6xl">
+              <h1 className="text-balance text-shadow-hero text-4xl font-semibold leading-tight tracking-tight text-[color:var(--surface)] sm:text-5xl lg:text-6xl">
                 AI Resume Optimizer
               </h1>
-              <p className="text-balance text-pretty text-shadow-hero mt-4 max-w-xl text-base leading-relaxed text-surface-50/95 sm:text-lg">
+              <p className="text-balance text-pretty text-shadow-hero mt-4 max-w-xl text-base leading-relaxed text-[color:color-mix(in_oklab,var(--surface),transparent_12%)] sm:text-lg">
                 Transform your experience into a story. Our AI analyzes, matches, and optimizes your resume.
               </p>
             </div>
             <dl className="grid grid-cols-1 gap-4 text-left sm:grid-cols-3">
               <div
                 className={cn(
-                  "card-glow group rounded-2xl border border-surface-50/20 bg-sand-50/95 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-sand-50 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70",
+                  "card-glow group rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
                   prefersReducedMotion
                     ? ""
-                    : "transform-gpu transition-[opacity,transform] duration-[520ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
+                    : "transform-gpu transition-[opacity,transform] duration-[280ms] ease-[var(--transition-snappy)]",
                   heroVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
                 )}
                 style={
@@ -267,10 +263,10 @@ export default function Header() {
               </div>
               <div
                 className={cn(
-                  "card-glow group rounded-2xl border border-surface-50/20 bg-sand-50/95 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-sand-50 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70",
+                  "card-glow group rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
                   prefersReducedMotion
                     ? ""
-                    : "transform-gpu transition-[opacity,transform] duration-[520ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
+                    : "transform-gpu transition-[opacity,transform] duration-[280ms] ease-[var(--transition-snappy)]",
                   heroVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
                 )}
                 style={
@@ -286,10 +282,10 @@ export default function Header() {
               </div>
               <div
                 className={cn(
-                  "card-glow group rounded-2xl border border-surface-50/20 bg-sand-50/95 p-4 text-ink-700 shadow-sm backdrop-blur-sm sm:backdrop-blur-xl transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-sand-50 hover:shadow-md dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70",
+                  "card-glow group rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
                   prefersReducedMotion
                     ? ""
-                    : "transform-gpu transition-[opacity,transform] duration-[520ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
+                    : "transform-gpu transition-[opacity,transform] duration-[280ms] ease-[var(--transition-snappy)]",
                   heroVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
                 )}
                 style={
@@ -308,10 +304,10 @@ export default function Header() {
 
           <div
             className={cn(
-              "card-glow group rounded-[var(--radius-card)] border border-surface-50/20 bg-sand-50/95 p-6 text-ink-700 shadow-md backdrop-blur-sm transition-all duration-200 ease-out hover:-translate-y-0.5 hover:bg-sand-50 hover:shadow-lg sm:backdrop-blur-xl dark:border-surface-50/10 dark:bg-zinc-900/60 dark:text-surface-50 dark:hover:bg-zinc-900/70",
+              "card-glow group rounded-[var(--radius-card)] border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-6 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
               prefersReducedMotion
                 ? ""
-                : "transform-gpu transition-[opacity,transform] duration-[560ms] ease-[cubic-bezier(0.16,1,0.3,1)]",
+                : "transform-gpu transition-[opacity,transform] duration-[300ms] ease-[var(--transition-snappy)]",
               workflowVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
             )}
             style={
@@ -325,7 +321,7 @@ export default function Header() {
             <h2 className="text-lg font-semibold tracking-wide text-ink-900 dark:text-surface-50">Your Saudi-ready workflow</h2>
             <ul className="mt-6 space-y-5 text-sm text-ink-500 dark:text-surface-50/85">
               <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-surface-50/70 text-[color:var(--secondary)] shadow-sm dark:bg-surface-50/15 dark:text-surface-50">
+                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
                   <FileText className="h-4 w-4" aria-hidden="true" />
                 </span>
                 <div>
@@ -334,7 +330,7 @@ export default function Header() {
                 </div>
               </li>
               <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-surface-50/70 text-[color:var(--secondary)] shadow-sm dark:bg-surface-50/15 dark:text-surface-50">
+                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
                   <Target className="h-4 w-4" aria-hidden="true" />
                 </span>
                 <div>
@@ -343,7 +339,7 @@ export default function Header() {
                 </div>
               </li>
               <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-surface-50/70 text-[color:var(--secondary)] shadow-sm dark:bg-surface-50/15 dark:text-surface-50">
+                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
                   <Sparkles className="h-4 w-4" aria-hidden="true" />
                 </span>
                 <div>
@@ -364,7 +360,7 @@ export default function Header() {
           <div
             aria-hidden="true"
             className={cn(
-              "bg-hero absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-700 md:bg-fixed md:bg-[position:50%_35%]",
+              "bg-hero absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-300 md:bg-fixed md:bg-[position:50%_35%]",
               skylineLoaded && animateSkyline ? "skyline-once" : "skyline-still",
               !skylineLoaded && "opacity-0"
             )}
@@ -377,10 +373,10 @@ export default function Header() {
       <div
         aria-hidden="true"
         className={cn(
-          "absolute inset-0 -z-30 pointer-events-none transition-colors duration-700",
+          "absolute inset-0 -z-30 pointer-events-none transition-colors duration-300",
           isDark
-            ? "bg-[radial-gradient(circle_at_18%_-12%,color-mix(in_oklab,var(--accent),transparent_82%)_0%,transparent_58%),radial-gradient(circle_at_82%_-18%,color-mix(in_oklab,var(--accent-gold),transparent_88%)_0%,transparent_68%),linear-gradient(to_bottom,color-mix(in_oklab,var(--surface),transparent_12%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_46%)_100%)]"
-            : "bg-[radial-gradient(circle_at_16%_-16%,color-mix(in_oklab,var(--accent),transparent_88%)_0%,transparent_62%),radial-gradient(circle_at_84%_-14%,color-mix(in_oklab,var(--accent-gold),transparent_90%)_0%,transparent_70%),linear-gradient(to_bottom,color-mix(in_oklab,var(--bg),transparent_12%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_58%)_100%)]",
+            ? "bg-[radial-gradient(circle_at_24%_-6%,color-mix(in_oklab,var(--accent),transparent_82%)_0%,transparent_58%),radial-gradient(circle_at_78%_-16%,color-mix(in_oklab,#8b5cf6,transparent_72%)_0%,transparent_68%),linear-gradient(to_bottom,color-mix(in_oklab,var(--surface),transparent_10%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_52%)_100%)]"
+            : "bg-[radial-gradient(circle_at_20%_-10%,color-mix(in_oklab,#a855f7,transparent_78%)_0%,transparent_60%),radial-gradient(circle_at_80%_-14%,color-mix(in_oklab,#ec4899,transparent_82%)_0%,transparent_68%),linear-gradient(to_bottom,color-mix(in_oklab,var(--bg),transparent_06%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_50%)_100%)]",
         )}
       />
       <div

--- a/src/components/ui/PrimaryButton.jsx
+++ b/src/components/ui/PrimaryButton.jsx
@@ -12,13 +12,11 @@ export default function PrimaryButton({
   return (
     <button
       className={cn(
-        "relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-        "border border-[color:color-mix(in_oklab,var(--accent),transparent_42%)] bg-[radial-gradient(circle_at_20%_-20%,color-mix(in_oklab,var(--surface),transparent_75%)_0%,transparent_55%),color-mix(in_oklab,var(--accent),transparent_35%)] text-[color:var(--surface)] shadow-[0_26px_70px_-38px_color-mix(in_oklab,var(--accent),transparent_48%)] backdrop-blur-xl",
-        "hover:-translate-y-0.5 hover:shadow-[0_38px_92px_-40px_color-mix(in_oklab,var(--accent),transparent_40%)]",
-        "focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-[color:var(--bg)] dark:focus-visible:ring-offset-[color:var(--surface)]",
-        "before:pointer-events-none before:absolute before:inset-[1px] before:rounded-[calc(var(--radius-card)_/_1.8)] before:bg-[linear-gradient(120deg,transparent_0%,color-mix(in_oklab,var(--accent-gold),transparent_55%)_35%,var(--accent-gold)_55%,transparent_100%)] before:bg-[length:220%_100%] before:opacity-0 before:transition-opacity before:duration-[var(--duration-snappy)] before:ease-[var(--transition-snappy)] before:content-[''] hover:before:opacity-100 focus-visible:before:opacity-100 motion-safe:hover:before:animate-[accent-shimmer_1.4s_linear] motion-safe:focus-visible:before:animate-[accent-shimmer_1.4s_linear] motion-reduce:hover:before:animate-none motion-reduce:focus-visible:before:animate-none",
-        "after:pointer-events-none after:absolute after:inset-[2px] after:rounded-[calc(var(--radius-card)_/_1.9)] after:border after:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_34%)] after:opacity-75 after:content-['']",
-        "disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:color-mix(in_oklab,var(--accent),transparent_70%)] disabled:bg-[color-mix(in_oklab,var(--accent),transparent_68%)] disabled:text-[color:color-mix(in_oklab,var(--surface),transparent_35%)] disabled:shadow-none disabled:before:hidden disabled:after:hidden",
+        "relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-white transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        "border border-transparent bg-[var(--button-primary-gradient)] shadow-[var(--button-primary-shadow)]",
+        "hover:-translate-y-0.5 hover:shadow-[var(--button-primary-shadow-strong)]",
+        "focus-visible:ring-[color:var(--button-primary-focus)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]",
+        "disabled:translate-y-0 disabled:cursor-not-allowed disabled:bg-[color-mix(in_oklab,var(--surface),transparent_16%)] disabled:text-[color:color-mix(in_oklab,var(--ink),transparent_54%)] disabled:shadow-none",
         className
       )}
       disabled={disabled || loading}
@@ -29,7 +27,7 @@ export default function PrimaryButton({
       ) : (
         Icon && <Icon className="relative z-10 h-4 w-4" aria-hidden="true" />
       )}
-      <span className="relative z-10 tracking-wide">{children}</span>
+      <span className="relative z-10">{children}</span>
     </button>
   );
 }

--- a/src/components/ui/SecondaryButton.jsx
+++ b/src/components/ui/SecondaryButton.jsx
@@ -4,18 +4,16 @@ export default function SecondaryButton({ children, className, icon: Icon, ...pr
   return (
     <button
       className={cn(
-        "relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-        "border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_46%)] bg-[color:var(--panel-bg)] text-[color:var(--ink)] shadow-[0_24px_64px_-40px_color-mix(in_oklab,var(--emerald-900),transparent_66%)] backdrop-blur-xl",
-        "hover:-translate-y-0.5 hover:shadow-[0_32px_86px_-42px_color-mix(in_oklab,var(--emerald-900),transparent_52%)] hover:text-[color:var(--ink)] focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_26%)] focus-visible:ring-offset-[color:var(--bg)] dark:focus-visible:ring-offset-[color:var(--surface)]",
-        "before:pointer-events-none before:absolute before:inset-[1px] before:rounded-[calc(var(--radius-card)_/_2.1)] before:bg-[linear-gradient(180deg,color-mix(in_oklab,var(--panel-highlight),transparent_35%)_0%,transparent_72%)] before:opacity-0 before:transition before:duration-500 before:ease-out before:content-[''] hover:before:opacity-100",
-        "after:pointer-events-none after:absolute after:inset-[2px] after:rounded-[calc(var(--radius-card)_/_2.2)] after:border after:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_58%)] after:opacity-70 after:content-['']",
-        "disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_58%)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_24%)] disabled:shadow-none disabled:before:hidden disabled:after:hidden",
+        "relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-[color:var(--ink)] transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        "border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] shadow-[var(--shadow-soft)]",
+        "hover:-translate-y-0.5 hover:shadow-[var(--shadow-lift)] hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]",
+        "disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_30%)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_32%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_18%)] disabled:shadow-none",
         className
       )}
       {...props}
     >
       {Icon && <Icon className="relative z-10 h-4 w-4" aria-hidden="true" />}
-      <span className="relative z-10 tracking-wide">{children}</span>
+      <span className="relative z-10">{children}</span>
     </button>
   );
 }

--- a/src/components/ui/SectionTitle.jsx
+++ b/src/components/ui/SectionTitle.jsx
@@ -4,25 +4,25 @@ export default function SectionTitle({ eyebrow, title, description, className })
   return (
     <div
       className={cn(
-        "group/section-title relative overflow-hidden rounded-[calc(var(--radius-card)_/_2.1)] border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_52%)] bg-[color:var(--panel-bg)] px-6 py-5 shadow-[0_26px_64px_-46px_color-mix(in_oklab,var(--emerald-900),transparent_70%)] backdrop-blur-xl transition-all duration-[var(--duration-breathe)] ease-[var(--transition-snappy)]",
-        "before:pointer-events-none before:absolute before:inset-0 before:bg-[radial-gradient(circle_at_top,color-mix(in_oklab,var(--panel-highlight),transparent_10%)_0%,transparent_70%)] before:opacity-80 before:content-['']",
+        "group/section-title relative overflow-hidden rounded-[calc(var(--radius-card)_/_2.1)] border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] px-6 py-5 shadow-[var(--shadow-soft)] transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)]",
+        "hover:shadow-[var(--shadow-lift)]",
         className,
       )}
     >
       {eyebrow && (
-        <p className="inline-flex items-center rounded-full border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_35%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-[color:var(--accent)] shadow-[0_10px_30px_-24px_color-mix(in_oklab,var(--emerald-900),transparent_70%)]">
+        <p className="inline-flex items-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-[color:var(--accent)]">
           {eyebrow}
         </p>
       )}
       {title && (
         <h2
-          className="relative text-2xl font-bold text-[color:var(--ink)] transition-colors duration-[var(--duration-breathe)] after:pointer-events-none after:absolute after:-bottom-1 after:left-0 after:h-px after:w-full after:rounded-full after:bg-[linear-gradient(120deg,transparent_0%,color-mix(in_oklab,var(--accent-gold),transparent_55%)_45%,var(--accent-gold)_55%,transparent_100%)] after:bg-[length:200%_100%] after:opacity-0 after:transition after:duration-[var(--duration-breathe)] after:ease-[var(--transition-snappy)] group-hover/section-title:after:opacity-100 group-focus-within/section-title:after:opacity-100 motion-safe:group-hover/section-title:after:animate-[accent-shimmer_1.6s_linear] motion-safe:group-focus-within/section-title:after:animate-[accent-shimmer_1.6s_linear] motion-reduce:group-hover/section-title:after:animate-none motion-reduce:group-focus-within/section-title:after:animate-none"
+          className="relative mt-2 text-2xl font-semibold tracking-tight text-[color:var(--ink)]"
         >
           {title}
         </h2>
       )}
       {description && (
-        <p className="text-sm leading-relaxed text-[color:var(--ink-muted)]">
+        <p className="mt-3 text-sm leading-relaxed text-[color:var(--ink-muted)]">
           {description}
         </p>
       )}

--- a/src/components/ui/UploadCard.jsx
+++ b/src/components/ui/UploadCard.jsx
@@ -149,7 +149,7 @@ export default function UploadCard({
 
   return (
     <section
-      className="space-y-6 rounded-[var(--radius-card)] border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_48%)] bg-[color:var(--panel-bg)] p-8 text-[color:var(--ink)] shadow-[0_32px_88px_-48px_color-mix(in_oklab,var(--emerald-900),transparent_68%)] backdrop-blur-xl dark:text-[color:var(--surface)]"
+      className="space-y-6 rounded-[var(--radius-card)] border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] p-8 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]"
       aria-live="polite"
     >
       <div className="space-y-2 text-left">
@@ -175,14 +175,14 @@ export default function UploadCard({
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         className={cn(
-          "relative flex flex-col items-center justify-center gap-3 rounded-[calc(var(--radius-card)_-_0.5rem)] border border-dashed border-[color:color-mix(in_oklab,var(--accent),transparent_48%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_4%)] px-6 py-12 text-center shadow-[0_28px_72px_-44px_color-mix(in_oklab,var(--emerald-900),transparent_62%)] backdrop-blur-xl transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_30%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]",
-          isDragging && "border-[color:color-mix(in_oklab,var(--accent),transparent_32%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] shadow-[0_32px_82px_-46px_color-mix(in_oklab,var(--emerald-900),transparent_54%)]"
+          "relative flex flex-col items-center justify-center gap-3 rounded-[calc(var(--radius-card)_-_0.5rem)] border border-dashed border-[color:color-mix(in_oklab,var(--accent),transparent_36%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_6%)] px-6 py-12 text-center shadow-[var(--shadow-soft)] transition-[border-color,box-shadow,transform,background-color] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_26%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]",
+          isDragging && "border-[color:color-mix(in_oklab,var(--accent),transparent_20%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] shadow-[var(--shadow-lift)]"
         )}
       >
-        <span className="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_50%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_6%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)] shadow-[0_12px_32px_-24px_color-mix(in_oklab,var(--emerald-900),transparent_70%)]">
+        <span className="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]">
           Max 5MB
         </span>
-        <div className="flex items-center gap-2 rounded-full border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_42%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] px-4 py-2 text-xs font-semibold text-[color:var(--ink)] shadow-[0_20px_48px_-34px_color-mix(in_oklab,var(--emerald-900),transparent_66%)] dark:text-[color:var(--surface)]">
+        <div className="flex items-center gap-2 rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-2 text-xs font-semibold text-[color:var(--ink)] shadow-[var(--shadow-soft)] dark:text-[color:var(--surface)]">
           <FileText className="h-4 w-4" aria-hidden="true" />
           <span>PDF</span>
           <span className="mx-1 text-[color:color-mix(in_oklab,var(--ink-500),transparent_40%)]">|</span>
@@ -208,12 +208,12 @@ export default function UploadCard({
       />
 
       {fileName && (
-        <div className="flex items-center justify-between rounded-2xl border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_52%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] px-4 py-3 text-sm text-[color:var(--ink)] shadow-[0_18px_44px_-32px_color-mix(in_oklab,var(--emerald-900),transparent_64%)] backdrop-blur-xl dark:text-[color:var(--surface)]">
+        <div className="flex items-center justify-between rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-3 text-sm text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]">
           <span className="truncate font-medium">{fileName}</span>
           <button
             type="button"
             onClick={onFileClear}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_55%)] text-[color:var(--accent)] transition-colors hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_20%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_26%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] text-[color:var(--accent)] transition-colors hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_16%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_24%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
             aria-label="Remove selected file"
           >
             <XCircle className="h-4 w-4" aria-hidden="true" />
@@ -227,7 +227,7 @@ export default function UploadCard({
           Paste resume text instead
         </span>
         <textarea
-          className="min-h-[160px] w-full resize-y rounded-2xl border border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_46%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_16%)] px-4 py-3 text-sm leading-relaxed text-[color:var(--ink)] shadow-[inset_0_1px_0_color-mix(in_oklab,var(--panel-highlight),transparent_25%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_30%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:text-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
+          className="min-h-[160px] w-full resize-y rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] px-4 py-3 text-sm leading-relaxed text-[color:var(--ink)] shadow-[inset_0_1px_0_color-mix(in_oklab,var(--panel-highlight),transparent_22%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:text-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
           placeholder="Paste resume text…"
           value={textValue}
           onChange={(event) => onTextChange?.(event.target.value)}

--- a/src/index.css
+++ b/src/index.css
@@ -124,7 +124,7 @@
   @keyframes hero-fade-in {
     from {
       opacity: 0;
-      transform: translateY(14px) scale(1.01);
+      transform: translateY(12px) scale(1.01);
     }
 
     to {
@@ -135,7 +135,7 @@
 
   .hero-fade {
     opacity: 0;
-    animation: hero-fade-in 520ms ease-out forwards;
+    animation: hero-fade-in 280ms ease-out forwards;
   }
 
   @keyframes hero-fade {
@@ -149,7 +149,7 @@
   }
 
   .hero-bg-animate {
-    animation: hero-fade 1.2s ease-out forwards;
+    animation: hero-fade 300ms ease-out forwards;
   }
 
   .text-shadow-hero {
@@ -285,16 +285,11 @@
   @keyframes skylineEntrance {
     0% {
       opacity: 0;
-      transform: translateY(24px) scale(1.05);
-    }
-
-    60% {
-      opacity: 0.85;
-      transform: translateY(4px) scale(1.01);
+      transform: translateY(16px) scale(1.02);
     }
 
     100% {
-      opacity: 0.85;
+      opacity: 0.9;
       transform: translateY(0) scale(1);
     }
   }
@@ -303,13 +298,13 @@
     position: relative;
     pointer-events: none;
     overflow: hidden;
-    filter: saturate(1.05) brightness(0.96);
+    filter: saturate(1.04) brightness(0.98);
     will-change: transform, opacity;
     transform: translateY(0) scale(1);
   }
 
   .skyline-once {
-    animation: skylineEntrance 1.6s ease-out forwards;
+    animation: skylineEntrance 300ms ease-out forwards;
   }
 
   .skyline-still {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,13 +1,13 @@
 :root {
-  --bg: #f4f9f6;
-  --surface: #ffffff;
-  --surface-strong: #e5f2eb;
-  --ink: #08291b;
-  --ink-muted: color-mix(in oklab, var(--ink), var(--bg) 55%);
-  --accent: #0f8a5f;
-  --secondary: #135f44;
-  --panel-bg: color-mix(in oklab, var(--surface), transparent 35%);
-  --panel-stroke: color-mix(in oklab, var(--ink), transparent 82%);
+  --bg: #f4f7f3;
+  --surface: #fefdfb;
+  --surface-strong: #e7f2ea;
+  --ink: #05271b;
+  --ink-muted: color-mix(in oklab, var(--ink), var(--bg) 52%);
+  --accent: #0e7c54;
+  --secondary: #146247;
+  --panel-bg: color-mix(in oklab, var(--surface), transparent 38%);
+  --panel-stroke: color-mix(in oklab, var(--ink), transparent 88%);
   /* Accessibility: palette ensures ≥4.5:1 contrast between ink text and key surfaces. */
 
   --surface-50: var(--bg);
@@ -29,21 +29,17 @@
   --accent-gold-rgb: 212 184 106;
 
   --panel-border: var(--panel-stroke);
-  --panel-highlight: color-mix(in oklab, var(--surface-strong), transparent 45%);
+  --panel-highlight: color-mix(in oklab, var(--surface-strong), transparent 42%);
 
-  --shadow-card-value: 0 28px 80px -46px color-mix(in oklab, var(--emerald-900), transparent 68%);
-  --shadow-soft-value: 0 18px 48px -32px color-mix(in oklab, var(--emerald-700), transparent 65%);
+  --shadow-card-value: 0 20px 60px -40px color-mix(in oklab, var(--emerald-900), transparent 76%);
+  --shadow-soft-value: 0 14px 38px -28px color-mix(in oklab, var(--emerald-700), transparent 74%);
+  --shadow-lift-value: 0 22px 64px -40px color-mix(in oklab, var(--emerald-900), transparent 70%);
 
   --duration-snappy: 180ms;
   --duration-breathe: 280ms;
   --transition-snappy: cubic-bezier(0.16, 1, 0.3, 1);
 
-  --gradient-primary-value: linear-gradient(
-    132deg,
-    color-mix(in oklab, var(--accent), var(--surface) 14%) 0%,
-    var(--accent) 50%,
-    color-mix(in oklab, var(--emerald-900), transparent 6%) 100%
-  );
+  --gradient-primary-value: linear-gradient(135deg, #6f3dcf 0%, #d946aa 100%);
   --gradient-muted-value: linear-gradient(
     135deg,
     color-mix(in oklab, var(--accent), transparent 88%) 0%,
@@ -57,9 +53,15 @@
 
   --shadow-card: var(--shadow-card-value);
   --shadow-soft: var(--shadow-soft-value);
+  --shadow-lift: var(--shadow-lift-value);
   --gradient-primary: var(--gradient-primary-value);
   --gradient-muted: var(--gradient-muted-value);
   --gradient-card: var(--gradient-card-value);
+
+  --button-primary-gradient: var(--gradient-primary-value);
+  --button-primary-shadow: 0 18px 42px -28px color-mix(in oklab, #d946aa, transparent 68%);
+  --button-primary-shadow-strong: 0 24px 52px -28px color-mix(in oklab, #c026d3, transparent 62%);
+  --button-primary-focus: color-mix(in oklab, #c084fc 60%, #f472b6);
 
   --color-primary-400: color-mix(in oklab, var(--accent), transparent 10%);
   --color-primary-500: var(--accent);
@@ -99,14 +101,14 @@
 :root.dark,
 .dark {
   --bg: #020c08;
-  --surface: #071611;
-  --surface-strong: #0f261c;
-  --ink: #e5f6ef;
-  --ink-muted: color-mix(in oklab, var(--ink), var(--surface) 35%);
-  --accent: #1aa877;
-  --secondary: #4dd0a1;
-  --panel-bg: color-mix(in oklab, var(--surface-strong), transparent 38%);
-  --panel-stroke: color-mix(in oklab, var(--ink), transparent 68%);
+  --surface: #06130f;
+  --surface-strong: #0d2217;
+  --ink: #e6f6ef;
+  --ink-muted: color-mix(in oklab, var(--ink), var(--surface) 40%);
+  --accent: #22b37d;
+  --secondary: #57d2a5;
+  --panel-bg: color-mix(in oklab, var(--surface-strong), transparent 34%);
+  --panel-stroke: color-mix(in oklab, var(--ink), transparent 82%);
 
   --surface-900: var(--bg);
   --surface-900-rgb: 2 12 8;
@@ -122,17 +124,13 @@
   --emerald-900-rgb: 11 106 73;
 
   --panel-border: var(--panel-stroke);
-  --panel-highlight: color-mix(in oklab, var(--surface-strong), transparent 38%);
+  --panel-highlight: color-mix(in oklab, var(--surface-strong), transparent 32%);
 
-  --shadow-card-value: 0 32px 82px -48px color-mix(in oklab, var(--emerald-900), transparent 58%);
-  --shadow-soft-value: 0 20px 52px -36px color-mix(in oklab, var(--emerald-900), transparent 60%);
+  --shadow-card-value: 0 20px 56px -36px color-mix(in oklab, var(--emerald-900), transparent 58%);
+  --shadow-soft-value: 0 14px 40px -28px color-mix(in oklab, var(--emerald-900), transparent 60%);
+  --shadow-lift-value: 0 24px 62px -36px color-mix(in oklab, var(--emerald-900), transparent 54%);
 
-  --gradient-primary-value: linear-gradient(
-    132deg,
-    color-mix(in oklab, var(--accent), transparent 10%) 0%,
-    color-mix(in oklab, var(--emerald-900), transparent 6%) 52%,
-    var(--emerald-900) 100%
-  );
+  --gradient-primary-value: linear-gradient(135deg, #8b5cf6 0%, #ec4899 100%);
   --gradient-muted-value: linear-gradient(
     135deg,
     color-mix(in oklab, var(--emerald-900), transparent 80%) 0%,
@@ -140,9 +138,14 @@
   );
   --gradient-card-value: linear-gradient(
     135deg,
-    color-mix(in oklab, var(--panel-highlight), transparent 40%) 0%,
-    color-mix(in oklab, var(--panel-highlight), transparent 72%) 100%
+    color-mix(in oklab, var(--panel-highlight), transparent 34%) 0%,
+    color-mix(in oklab, var(--panel-highlight), transparent 68%) 100%
   );
+
+  --button-primary-gradient: var(--gradient-primary-value);
+  --button-primary-shadow: 0 20px 44px -28px color-mix(in oklab, #ec4899, transparent 60%);
+  --button-primary-shadow-strong: 0 26px 52px -28px color-mix(in oklab, #f472b6, transparent 54%);
+  --button-primary-focus: color-mix(in oklab, #d8b4fe 55%, #f9a8d4);
 }
 
 @keyframes accent-shimmer {


### PR DESCRIPTION
## Summary
- refresh the Saudi theme palette with hairline panel strokes, softer elevations, and a new purple→magenta primary gradient token
- restyle hero, buttons, section headers, and the upload card to emphasise typography, hairline borders, and clearer focus treatments across light/dark modes
- tighten hero animations to 300ms, adjust radial overlays, and update UI tests and snapshots for the new styling tokens

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1ac87b5fc8330aa015d2f016f7dd5