### PR TITLE
Enhance Saudi assets, upload flow, and UI polish

### DIFF
--- a/src/__tests__/MainContent.test.jsx
+++ b/src/__tests__/MainContent.test.jsx
@@ -98,19 +98,48 @@ describe("MainContent resume parsing", () => {
     });
   });
 
-  it("passes File inputs directly to parseResume", async () => {
+  it("passes upload payloads through parseResume with storage metadata", async () => {
     render(<MainContent />);
 
     expect(resumeUploadMockProps.current).toBeTruthy();
     const file = new File(["%PDF-1.7 data"], "resume.pdf", {
       type: "application/pdf",
     });
+    const uploadPayload = {
+      kind: "upload",
+      file,
+      storage: {
+        bucket: "resumes",
+        path: "user-123/resume.pdf",
+        fileName: "resume.pdf",
+        userId: "user-123",
+      },
+    };
 
+    let parsed;
     await act(async () => {
-      await resumeUploadMockProps.current.onParseResume(file);
+      parsed = await resumeUploadMockProps.current.onParseResume(uploadPayload);
     });
 
     expect(parseResumeMock).toHaveBeenCalledTimes(1);
     expect(parseResumeMock).toHaveBeenCalledWith(file);
+    expect(parsed).toMatchObject({
+      storagePath: "user-123/resume.pdf",
+      storageBucket: "resumes",
+      storageFileName: "resume.pdf",
+      storageUserId: "user-123",
+    });
+  });
+
+  it("supports text payloads", async () => {
+    render(<MainContent />);
+
+    expect(resumeUploadMockProps.current).toBeTruthy();
+
+    await act(async () => {
+      await resumeUploadMockProps.current.onParseResume({ kind: "text", value: "My resume" });
+    });
+
+    expect(parseResumeMock).toHaveBeenCalledWith("My resume");
   });
 });

--- a/src/__tests__/ResumeUpload.test.jsx
+++ b/src/__tests__/ResumeUpload.test.jsx
@@ -52,7 +52,12 @@ describe("ResumeUpload", () => {
   it("uploads PDFs and shows a success toast", async () => {
     const onToast = vi.fn();
     const onParseResume = vi.fn().mockResolvedValue({});
-    uploadResumeFile.mockResolvedValueOnce({ path: "user-123/resume.pdf" });
+    uploadResumeFile.mockResolvedValueOnce({
+      path: "user-123/resume.pdf",
+      fileName: "resume.pdf",
+      userId: "user-123",
+      bucket: "resumes",
+    });
 
     render(<ResumeUpload onParseResume={onParseResume} onToast={onToast} />);
 
@@ -75,13 +80,42 @@ describe("ResumeUpload", () => {
     });
 
     expect(uploadResumeFile).toHaveBeenCalledWith(file, expect.any(Object));
-    expect(onParseResume).toHaveBeenCalledWith(file);
+    expect(onParseResume).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "upload",
+        file,
+        storage: expect.objectContaining({
+          bucket: "resumes",
+          path: "user-123/resume.pdf",
+          fileName: "resume.pdf",
+        }),
+      })
+    );
     expect(onToast).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "success",
         title: expect.stringMatching(/file uploaded/i),
       })
     );
+  });
+
+  it("passes pasted text to onParseResume with context", async () => {
+    const onToast = vi.fn();
+    const onParseResume = vi.fn().mockResolvedValue({ plainText: "Resume text" });
+
+    render(<ResumeUpload onParseResume={onParseResume} onToast={onToast} />);
+
+    const textarea = screen.getByPlaceholderText(/paste resume text/i);
+    fireEvent.change(textarea, { target: { value: "  My resume text  " } });
+
+    const submitButton = screen.getByRole("button", { name: /prepare resume/i });
+
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    expect(onParseResume).toHaveBeenCalledWith({ kind: "text", value: "My resume text" });
+    expect(textarea).toHaveValue("Resume text");
   });
 
   it("rejects files over 5MB with a warning toast", async () => {

--- a/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
+++ b/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
 <div>
   <section
     aria-live="polite"
-    class="space-y-6 rounded-[var(--radius-card)] border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] p-8 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]"
+    class="space-y-6 rounded-[var(--radius-card)] border border-[color:var(--hairline-strong)] bg-[color:var(--panel-bg)] p-8 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]"
   >
     <div
       class="space-y-2 text-left"
@@ -32,12 +32,12 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
       tabindex="0"
     >
       <span
-        class="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]"
+        class="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:var(--hairline-soft)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]"
       >
         Max 5MB
       </span>
       <div
-        class="flex items-center gap-2 rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-2 text-xs font-semibold text-[color:var(--ink)] shadow-[var(--shadow-soft)] dark:text-[color:var(--surface)]"
+        class="flex items-center gap-2 rounded-full border border-[color:var(--hairline-soft)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-2 text-xs font-semibold text-[color:var(--ink)] shadow-[var(--shadow-soft)] dark:text-[color:var(--surface)]"
       >
         <svg
           aria-hidden="true"
@@ -163,7 +163,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
         Paste resume text instead
       </span>
       <textarea
-        class="min-h-[160px] w-full resize-y rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] px-4 py-3 text-sm leading-relaxed text-[color:var(--ink)] shadow-[inset_0_1px_0_color-mix(in_oklab,var(--panel-highlight),transparent_22%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:text-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
+        class="min-h-[160px] w-full resize-y rounded-2xl border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] px-4 py-3 text-sm leading-relaxed text-[color:var(--ink)] shadow-[inset_0_1px_0_color-mix(in_oklab,var(--panel-highlight),transparent_22%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:text-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
         placeholder="Paste resume text…"
       />
     </label>
@@ -171,7 +171,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
       class="flex flex-wrap items-center gap-3"
     >
       <button
-        class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-white transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-transparent bg-[var(--button-primary-gradient)] shadow-[var(--button-primary-shadow)] hover:-translate-y-0.5 hover:shadow-[var(--button-primary-shadow-strong)] focus-visible:ring-[color:var(--button-primary-focus)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)] disabled:translate-y-0 disabled:cursor-not-allowed disabled:bg-[color-mix(in_oklab,var(--surface),transparent_16%)] disabled:text-[color:color-mix(in_oklab,var(--ink),transparent_54%)] disabled:shadow-none"
+        class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-white transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-[color:var(--button-primary-border)] bg-[var(--button-primary-gradient)] shadow-[var(--button-primary-shadow)] before:pointer-events-none before:absolute before:inset-px before:rounded-[inherit] before:bg-[var(--button-primary-overlay)] before:opacity-0 before:transition-opacity before:duration-300 hover:-translate-y-0.5 hover:shadow-[var(--button-primary-shadow-strong)] hover:before:opacity-100 focus-visible:ring-[color:var(--button-primary-focus)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)] disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:var(--hairline-muted)] disabled:bg-[color-mix(in_oklab,var(--surface),transparent_16%)] disabled:text-[color:color-mix(in_oklab,var(--ink),transparent_54%)] disabled:shadow-none"
       >
         <span
           class="relative z-10"
@@ -180,7 +180,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
         </span>
       </button>
       <button
-        class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-[color:var(--ink)] transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] shadow-[var(--shadow-soft)] hover:-translate-y-0.5 hover:shadow-[var(--shadow-lift)] hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)] disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_30%)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_32%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_18%)] disabled:shadow-none"
+        class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-[color:var(--ink)] transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-[color:var(--hairline-strong)] bg-[color:var(--panel-bg)] shadow-[var(--shadow-soft)] before:pointer-events-none before:absolute before:inset-px before:rounded-[inherit] before:bg-[color:color-mix(in_oklab,var(--panel-highlight),transparent_20%)] before:opacity-0 before:transition-opacity before:duration-300 hover:-translate-y-0.5 hover:shadow-[var(--shadow-lift)] hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] hover:before:opacity-100 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)] disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:var(--hairline-muted)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_32%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_18%)] disabled:shadow-none"
         disabled=""
       >
         <svg

--- a/src/__tests__/supabase.test.js
+++ b/src/__tests__/supabase.test.js
@@ -46,7 +46,12 @@ describe("supabase upload service", () => {
     expect(uploadSpy.mock.calls[0][0]).toBe("user-123/resume.pdf");
     expect(uploadSpy.mock.calls[1][0]).toBe("user-123/resume-v2.pdf");
     expect(uploadSpy.mock.calls[0][2]).toMatchObject({ contentType: "application/pdf" });
-    expect(result).toEqual({ path: "user-123/resume-v2.pdf", fileName: "resume-v2.pdf", userId: "user-123" });
+    expect(result).toEqual({
+      path: "user-123/resume-v2.pdf",
+      fileName: "resume-v2.pdf",
+      userId: "user-123",
+      bucket: "resumes",
+    });
     expect(progressSpy).toHaveBeenCalledWith({ loaded: 5, total: 10 });
   });
 
@@ -62,7 +67,12 @@ describe("supabase upload service", () => {
       file,
       expect.objectContaining({ contentType: file.type, upsert: false })
     );
-    expect(result).toEqual({ path: "user-456/resume.docx", fileName: "resume.docx", userId: "user-456" });
+    expect(result).toEqual({
+      path: "user-456/resume.docx",
+      fileName: "resume.docx",
+      userId: "user-456",
+      bucket: "resumes",
+    });
   });
 
   it("uses the file content type when provided", async () => {
@@ -136,5 +146,15 @@ describe("supabase upload service", () => {
     await expect(uploadResumeFile({ name: "resume.pdf" })).rejects.toMatchObject({
       code: "auth/unauthorized",
     });
+  });
+
+  it("throws when the authenticated user id is missing", async () => {
+    authMock.getUser.mockResolvedValue({ data: { user: { id: "   " } }, error: null });
+
+    await expect(uploadResumeFile({ name: "resume.pdf", type: "application/pdf" })).rejects.toMatchObject({
+      code: "auth/unauthenticated",
+      message: expect.stringMatching(/missing user id/i),
+    });
+    expect(uploadSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -30,7 +30,6 @@ export default function Header() {
   const skylineUrl = useMemo(() => {
     try {
       const url = getSkylineUrl();
-      console.log("[skylineUrl]", url);
       return url;
     } catch (error) {
       console.error("Failed to resolve skyline asset", error);
@@ -39,6 +38,10 @@ export default function Header() {
   }, []);
   const [skylineLoaded, setSkylineLoaded] = useState(false);
   const [animateSkyline, setAnimateSkyline] = useState(false);
+  const isFallbackSkyline = useMemo(
+    () => typeof skylineUrl === "string" && skylineUrl.startsWith("data:image/"),
+    [skylineUrl]
+  );
   const initialReducedMotion = useMemo(getPrefersReducedMotion, []);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(initialReducedMotion);
   const [heroVisible, setHeroVisible] = useState(initialReducedMotion);
@@ -69,14 +72,14 @@ export default function Header() {
   }, [skylineUrl]);
 
   useEffect(() => {
-    if (typeof window === "undefined" || !skylineUrl || !skylineLoaded) {
+    if (typeof window === "undefined" || !skylineUrl || !skylineLoaded || isFallbackSkyline) {
       return undefined;
     }
 
     setAnimateSkyline(true);
     const timer = window.setTimeout(() => setAnimateSkyline(false), 1800);
     return () => window.clearTimeout(timer);
-  }, [skylineUrl, skylineLoaded]);
+  }, [isFallbackSkyline, skylineLoaded, skylineUrl]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -173,7 +176,7 @@ export default function Header() {
           heroMinHeightClass,
         )}
       >
-        <div className="border-b border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_38%)]">
+        <div className="border-b border-[color:var(--hairline-soft)]">
           <div className={`${containerClass} flex items-center justify-between gap-4 py-4 sm:py-6`}>
             <div
               className="flex items-center gap-3"
@@ -181,12 +184,15 @@ export default function Header() {
                 enableArabicBrand ? ` — ${arabicBrandName}` : ""
               } — By Abdullah bin Ahmed`}
             >
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] text-[color:var(--accent)] shadow-[var(--shadow-soft)]">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] text-[color:var(--accent)] shadow-[var(--shadow-soft)]">
                 <Sparkles className="h-5 w-5" aria-hidden="true" />
               </span>
               <div className="flex flex-col gap-1 text-left">
                 <p className="text-[11px] font-semibold uppercase tracking-[0.45em] text-accent-400/90">
                   AI Resume Optimizer
+                </p>
+                <p className="text-sm font-semibold uppercase tracking-[0.32em] text-surface-50/90">
+                  By Abdullah bin Ahmed
                 </p>
                 {enableArabicBrand ? (
                   <p
@@ -197,9 +203,6 @@ export default function Header() {
                     {arabicBrandName}
                   </p>
                 ) : null}
-                <p className="text-sm font-semibold uppercase tracking-[0.32em] text-surface-50/90">
-                  By Abdullah bin Ahmed
-                </p>
               </div>
             </div>
             <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-end">
@@ -245,7 +248,7 @@ export default function Header() {
             >
               Designed for Saudi ambition
             </span>
-            <div className="relative max-w-2xl rounded-[var(--radius-card)] border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] p-6 text-[color:var(--surface)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] sm:p-7 lg:p-8">
+            <div className="relative max-w-2xl rounded-[var(--radius-card)] border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] p-6 text-[color:var(--surface)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] sm:p-7 lg:p-8">
               <span
                 aria-hidden="true"
                 className="absolute -top-8 left-6 text-accent-400 drop-shadow-[0_0_12px_rgba(197,166,106,0.35)]"
@@ -262,7 +265,7 @@ export default function Header() {
             <dl className="grid grid-cols-1 gap-4 text-left sm:grid-cols-3">
               <div
                 className={cn(
-                  "card-glow group rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
+                  "card-glow group rounded-2xl border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
                   prefersReducedMotion
                     ? ""
                     : "transform-gpu transition-[opacity,transform] duration-[280ms] ease-[var(--transition-snappy)]",
@@ -281,7 +284,7 @@ export default function Header() {
               </div>
               <div
                 className={cn(
-                  "card-glow group rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
+                  "card-glow group rounded-2xl border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
                   prefersReducedMotion
                     ? ""
                     : "transform-gpu transition-[opacity,transform] duration-[280ms] ease-[var(--transition-snappy)]",
@@ -300,7 +303,7 @@ export default function Header() {
               </div>
               <div
                 className={cn(
-                  "card-glow group rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
+                  "card-glow group rounded-2xl border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-4 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
                   prefersReducedMotion
                     ? ""
                     : "transform-gpu transition-[opacity,transform] duration-[280ms] ease-[var(--transition-snappy)]",
@@ -322,7 +325,7 @@ export default function Header() {
 
           <div
             className={cn(
-              "card-glow group rounded-[var(--radius-card)] border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-6 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
+              "card-glow group rounded-[var(--radius-card)] border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_22%)] p-6 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-[transform,box-shadow,background-color] duration-280 ease-[var(--transition-snappy)] hover:-translate-y-0.5 hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_28%)] hover:shadow-[var(--shadow-lift)] dark:text-[color:var(--surface)]",
               prefersReducedMotion
                 ? ""
                 : "transform-gpu transition-[opacity,transform] duration-[300ms] ease-[var(--transition-snappy)]",
@@ -339,7 +342,7 @@ export default function Header() {
             <h2 className="text-lg font-semibold tracking-wide text-ink-900 dark:text-surface-50">Your Saudi-ready workflow</h2>
             <ul className="mt-6 space-y-5 text-sm text-ink-500 dark:text-surface-50/85">
               <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
+                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
                   <FileText className="h-4 w-4" aria-hidden="true" />
                 </span>
                 <div>
@@ -348,7 +351,7 @@ export default function Header() {
                 </div>
               </li>
               <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
+                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
                   <Target className="h-4 w-4" aria-hidden="true" />
                 </span>
                 <div>
@@ -357,7 +360,7 @@ export default function Header() {
                 </div>
               </li>
               <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
+                <span className="mt-1 inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_12%)] text-[color:var(--secondary)] shadow-[var(--shadow-soft)]">
                   <Sparkles className="h-4 w-4" aria-hidden="true" />
                 </span>
                 <div>
@@ -378,7 +381,8 @@ export default function Header() {
           <div
             aria-hidden="true"
             className={cn(
-              "bg-hero absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-300 md:bg-fixed md:bg-[position:50%_35%]",
+              "bg-hero absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-300",
+              !isFallbackSkyline && "md:bg-fixed md:bg-[position:50%_35%]",
               skylineLoaded && animateSkyline ? "skyline-once" : "skyline-still",
               !skylineLoaded && "opacity-0"
             )}
@@ -396,6 +400,11 @@ export default function Header() {
             ? "bg-[radial-gradient(circle_at_24%_-6%,color-mix(in_oklab,var(--accent),transparent_82%)_0%,transparent_58%),radial-gradient(circle_at_78%_-16%,color-mix(in_oklab,#8b5cf6,transparent_72%)_0%,transparent_68%),linear-gradient(to_bottom,color-mix(in_oklab,var(--surface),transparent_10%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_52%)_100%)]"
             : "bg-[radial-gradient(circle_at_20%_-10%,color-mix(in_oklab,#a855f7,transparent_78%)_0%,transparent_60%),radial-gradient(circle_at_80%_-14%,color-mix(in_oklab,#ec4899,transparent_82%)_0%,transparent_68%),linear-gradient(to_bottom,color-mix(in_oklab,var(--bg),transparent_06%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_50%)_100%)]",
         )}
+      />
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 -z-25 pointer-events-none opacity-80 mix-blend-screen"
+        style={{ backgroundImage: "var(--hero-overlay-sheen)" }}
       />
       <div
         className="absolute inset-0 -z-20 opacity-[0.08] mix-blend-soft-light"

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -150,8 +150,30 @@ export default function MainContent() {
     setPreviewUsed(true);
   }, []);
 
+  const normalizeResumePayload = useCallback((input) => {
+    if (input && typeof input === "object") {
+      if (input.kind === "upload") {
+        const { file, storage } = input;
+        return {
+          parseInput: file,
+          storage: storage && typeof storage === "object" ? storage : null,
+        };
+      }
+
+      if (input.kind === "text") {
+        return {
+          parseInput: input.value,
+          storage: null,
+        };
+      }
+    }
+
+    return { parseInput: input, storage: null };
+  }, []);
+
   const handleParseResume = useCallback(
     async (resumeInput) => {
+      const { parseInput, storage } = normalizeResumePayload(resumeInput);
       try {
         setFlowProgress(18);
         pushToast(
@@ -164,9 +186,19 @@ export default function MainContent() {
         );
 
         setFlowProgress(48);
-        const parsed = await parseResume(resumeInput);
+        const parsed = await parseResume(parseInput);
         setFlowProgress(88);
-        setResumeData(parsed);
+        const enriched =
+          parsed && storage
+            ? {
+                ...parsed,
+                storagePath: storage.path,
+                storageBucket: storage.bucket,
+                storageFileName: storage.fileName,
+                storageUserId: storage.userId,
+              }
+            : parsed;
+        setResumeData(enriched);
         setMatchAnalysis(null);
         setJobDescription("");
         setOptimizations([]);
@@ -181,7 +213,7 @@ export default function MainContent() {
         );
         setFlowProgress(100);
         scheduleTimeout(() => setFlowProgress(0), 800);
-        return parsed;
+        return enriched;
       } catch (error) {
         setFlowProgress(0);
         pushToast(
@@ -196,7 +228,7 @@ export default function MainContent() {
         throw error;
       }
     },
-    [pushToast]
+    [normalizeResumePayload, pushToast]
   );
 
   const handleAnalyzeMatch = useCallback(

--- a/src/components/ui/PrimaryButton.jsx
+++ b/src/components/ui/PrimaryButton.jsx
@@ -13,10 +13,11 @@ export default function PrimaryButton({
     <button
       className={cn(
         "relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-white transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-        "border border-transparent bg-[var(--button-primary-gradient)] shadow-[var(--button-primary-shadow)]",
-        "hover:-translate-y-0.5 hover:shadow-[var(--button-primary-shadow-strong)]",
+        "border border-[color:var(--button-primary-border)] bg-[var(--button-primary-gradient)] shadow-[var(--button-primary-shadow)]",
+        "before:pointer-events-none before:absolute before:inset-px before:rounded-[inherit] before:bg-[var(--button-primary-overlay)] before:opacity-0 before:transition-opacity before:duration-300",
+        "hover:-translate-y-0.5 hover:shadow-[var(--button-primary-shadow-strong)] hover:before:opacity-100",
         "focus-visible:ring-[color:var(--button-primary-focus)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]",
-        "disabled:translate-y-0 disabled:cursor-not-allowed disabled:bg-[color-mix(in_oklab,var(--surface),transparent_16%)] disabled:text-[color:color-mix(in_oklab,var(--ink),transparent_54%)] disabled:shadow-none",
+        "disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:var(--hairline-muted)] disabled:bg-[color-mix(in_oklab,var(--surface),transparent_16%)] disabled:text-[color:color-mix(in_oklab,var(--ink),transparent_54%)] disabled:shadow-none",
         className
       )}
       disabled={disabled || loading}

--- a/src/components/ui/SecondaryButton.jsx
+++ b/src/components/ui/SecondaryButton.jsx
@@ -5,9 +5,10 @@ export default function SecondaryButton({ children, className, icon: Icon, ...pr
     <button
       className={cn(
         "relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-[color:var(--ink)] transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-        "border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] shadow-[var(--shadow-soft)]",
-        "hover:-translate-y-0.5 hover:shadow-[var(--shadow-lift)] hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]",
-        "disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:color-mix(in_oklab,var(--panel-stroke),transparent_30%)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_32%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_18%)] disabled:shadow-none",
+        "border border-[color:var(--hairline-strong)] bg-[color:var(--panel-bg)] shadow-[var(--shadow-soft)]",
+        "before:pointer-events-none before:absolute before:inset-px before:rounded-[inherit] before:bg-[color:color-mix(in_oklab,var(--panel-highlight),transparent_20%)] before:opacity-0 before:transition-opacity before:duration-300",
+        "hover:-translate-y-0.5 hover:shadow-[var(--shadow-lift)] hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] hover:before:opacity-100 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]",
+        "disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:var(--hairline-muted)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_32%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_18%)] disabled:shadow-none",
         className
       )}
       {...props}

--- a/src/components/ui/UploadCard.jsx
+++ b/src/components/ui/UploadCard.jsx
@@ -149,7 +149,7 @@ export default function UploadCard({
 
   return (
     <section
-      className="space-y-6 rounded-[var(--radius-card)] border border-[color:var(--panel-stroke)] bg-[color:var(--panel-bg)] p-8 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]"
+      className="space-y-6 rounded-[var(--radius-card)] border border-[color:var(--hairline-strong)] bg-[color:var(--panel-bg)] p-8 text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]"
       aria-live="polite"
     >
       <div className="space-y-2 text-left">
@@ -179,10 +179,10 @@ export default function UploadCard({
           isDragging && "border-[color:color-mix(in_oklab,var(--accent),transparent_20%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] shadow-[var(--shadow-lift)]"
         )}
       >
-        <span className="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]">
+        <span className="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:var(--hairline-soft)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]">
           Max 5MB
         </span>
-        <div className="flex items-center gap-2 rounded-full border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-2 text-xs font-semibold text-[color:var(--ink)] shadow-[var(--shadow-soft)] dark:text-[color:var(--surface)]">
+        <div className="flex items-center gap-2 rounded-full border border-[color:var(--hairline-soft)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-2 text-xs font-semibold text-[color:var(--ink)] shadow-[var(--shadow-soft)] dark:text-[color:var(--surface)]">
           <FileText className="h-4 w-4" aria-hidden="true" />
           <span>PDF</span>
           <span className="mx-1 text-[color:color-mix(in_oklab,var(--ink-500),transparent_40%)]">|</span>
@@ -208,12 +208,12 @@ export default function UploadCard({
       />
 
       {fileName && (
-        <div className="flex items-center justify-between rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-3 text-sm text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]">
+        <div className="flex items-center justify-between rounded-2xl border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-3 text-sm text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]">
           <span className="truncate font-medium">{fileName}</span>
           <button
             type="button"
             onClick={onFileClear}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--panel-stroke)] text-[color:var(--accent)] transition-colors hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_16%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_24%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--hairline-soft)] text-[color:var(--accent)] transition-colors hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_16%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_24%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
             aria-label="Remove selected file"
           >
             <XCircle className="h-4 w-4" aria-hidden="true" />
@@ -227,7 +227,7 @@ export default function UploadCard({
           Paste resume text instead
         </span>
         <textarea
-          className="min-h-[160px] w-full resize-y rounded-2xl border border-[color:var(--panel-stroke)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] px-4 py-3 text-sm leading-relaxed text-[color:var(--ink)] shadow-[inset_0_1px_0_color-mix(in_oklab,var(--panel-highlight),transparent_22%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:text-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
+          className="min-h-[160px] w-full resize-y rounded-2xl border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_18%)] px-4 py-3 text-sm leading-relaxed text-[color:var(--ink)] shadow-[inset_0_1px_0_color-mix(in_oklab,var(--panel-highlight),transparent_22%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:text-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
           placeholder="Paste resume text…"
           value={textValue}
           onChange={(event) => onTextChange?.(event.target.value)}

--- a/src/features/ResumeUpload.jsx
+++ b/src/features/ResumeUpload.jsx
@@ -11,6 +11,7 @@ const DOCUMENT_EXTENSIONS = new Set(["pdf", "docx"]);
 
 const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
 const PDF_HELPER_MESSAGE = "This looks like a PDF — use Upload.";
+const RESUME_BUCKET = "resumes";
 const ERROR_MESSAGES = {
   "file/unsupported-type": {
     type: "warning",
@@ -207,9 +208,11 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
       setError("");
       setProgress(0);
 
+      let storageMetadata = null;
+
       if (file) {
         setStatus("uploading");
-        await uploadResumeFile(file, {
+        const uploadResult = await uploadResumeFile(file, {
           onProgress: ({ loaded, total }) => {
             if (!total) return;
             const percent = Math.round((loaded / total) * 60);
@@ -218,16 +221,35 @@ export default function ResumeUpload({ onParseResume, resumeDocument, onToast })
         });
 
         setProgress((prev) => Math.max(prev, 70));
+        if (uploadResult) {
+          storageMetadata = {
+            bucket: uploadResult.bucket || RESUME_BUCKET,
+            path: uploadResult.path,
+            fileName: uploadResult.fileName,
+            userId: uploadResult.userId,
+          };
+        }
         onToast?.({
           type: "success",
           title: "File uploaded",
-          description: "Resume stored securely. Parsing next…",
+          description: storageMetadata
+            ? `Stored securely as ${storageMetadata.fileName}. Parsing next…`
+            : "Resume stored securely. Parsing next…",
         });
       }
 
       setStatus("parsing");
       setProgress((prev) => Math.max(prev, 80));
-      const payload = file || textValue;
+      const payload = file
+        ? {
+            kind: "upload",
+            file,
+            storage: storageMetadata,
+          }
+        : {
+            kind: "text",
+            value: trimmedText,
+          };
       const parsed = await onParseResume?.(payload);
       setProgress(100);
       setStatus("success");

--- a/src/index.css
+++ b/src/index.css
@@ -241,11 +241,11 @@
   .accent-divider {
     background: linear-gradient(
       90deg,
-      rgba(197, 166, 106, 0),
-      rgba(197, 166, 106, 0.75),
-      rgba(197, 166, 106, 0)
+      color-mix(in oklab, var(--accent-gold), transparent 94%) 0%,
+      color-mix(in oklab, var(--accent-gold), transparent 26%) 50%,
+      color-mix(in oklab, var(--accent-gold), transparent 94%) 100%
     );
-    box-shadow: 0 0 24px rgba(197, 166, 106, 0.45);
+    box-shadow: 0 0 24px color-mix(in oklab, var(--accent-gold), transparent 52%);
   }
 
   @keyframes subtleGlow {

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -156,4 +156,14 @@ describe("getSkylineUrl", () => {
       "https://project.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp?v=build-xyz",
     );
   });
+
+  it("falls back to a Saudi gradient when env config is missing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { getSkylineUrl, __internal } = await loadModule();
+    __internal.resetCache();
+    const skyline = getSkylineUrl();
+    expect(skyline).toMatch(/^data:image\/svg\+xml,/);
+    expect(skyline.length).toBeGreaterThan(120);
+    warnSpy.mockRestore();
+  });
 });

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -154,7 +154,13 @@ const ensureHostOnlyUrl = (value: string, sourceKey: string) => {
   return origin;
 };
 
+let cachedAssetsBaseHost: string | null | undefined;
+
 const readAssetsBaseHost = () => {
+  if (cachedAssetsBaseHost !== undefined) {
+    return cachedAssetsBaseHost;
+  }
+
   const warnInvalidEnv = (key: string, error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     warnHostOnlyEnv(`[assets] ${key} is invalid: ${message}`);
@@ -163,7 +169,8 @@ const readAssetsBaseHost = () => {
   const assetsBase = readEnvString("VITE_ASSETS_BASE_URL");
   if (assetsBase) {
     try {
-      return ensureHostOnlyUrl(assetsBase, "VITE_ASSETS_BASE_URL");
+      cachedAssetsBaseHost = ensureHostOnlyUrl(assetsBase, "VITE_ASSETS_BASE_URL");
+      return cachedAssetsBaseHost;
     } catch (error) {
       warnInvalidEnv("VITE_ASSETS_BASE_URL", error);
     }
@@ -172,13 +179,15 @@ const readAssetsBaseHost = () => {
   const supabaseUrl = readEnvString("VITE_SUPABASE_URL");
   if (supabaseUrl) {
     try {
-      return ensureHostOnlyUrl(supabaseUrl, "VITE_SUPABASE_URL");
+      cachedAssetsBaseHost = ensureHostOnlyUrl(supabaseUrl, "VITE_SUPABASE_URL");
+      return cachedAssetsBaseHost;
     } catch (error) {
       warnInvalidEnv("VITE_SUPABASE_URL", error);
     }
   }
 
-  return null;
+  cachedAssetsBaseHost = null;
+  return cachedAssetsBaseHost;
 };
 
 const normalizeBucketName = (bucket: string) => {
@@ -237,22 +246,34 @@ export const publicAssetUrl = (bucket: string, objectPath: string) => {
 const SKYLINE_BUCKET = "ui-assets";
 const SKYLINE_OBJECT_PATH = "KAFDH.webp";
 
+const FALLBACK_SKYLINE_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" fill="none"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0B6B3A" stop-opacity="0.78"/><stop offset="0.5" stop-color="#7C3AED" stop-opacity="0.74"/><stop offset="1" stop-color="#EC4899" stop-opacity="0.68"/></linearGradient></defs><rect width="1600" height="900" fill="url(#g)"/><g opacity="0.35" stroke="#F7F2E7" stroke-width="1.2"><path d="M160 720V420l120-60 120 60v300"/><path d="M520 720V360l140-80 140 80v360"/><path d="M880 720V300l160-90 160 90v420"/><path d="M1240 720V420l120-60 120 60v300"/></g><g opacity="0.18" fill="#F7F2E7"><circle cx="320" cy="240" r="36"/><circle cx="1280" cy="200" r="42"/><circle cx="1040" cy="160" r="24"/></g></svg>';
+
+const FALLBACK_SKYLINE_URL = `data:image/svg+xml,${encodeURIComponent(FALLBACK_SKYLINE_SVG)}`;
+
 let memoizedSkylineUrl: string | null = null;
 
 export const getSkylineUrl = () => {
   if (!memoizedSkylineUrl) {
     try {
       const resolvedUrl = publicAssetUrl(SKYLINE_BUCKET, SKYLINE_OBJECT_PATH);
-      memoizedSkylineUrl = resolvedUrl ? withVersion(resolvedUrl) : "";
+      memoizedSkylineUrl = resolvedUrl ? withVersion(resolvedUrl) : FALLBACK_SKYLINE_URL;
     } catch (error) {
       warnHostOnlyEnv(
         `[assets] Failed to resolve skyline asset: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
-      memoizedSkylineUrl = "";
+      memoizedSkylineUrl = FALLBACK_SKYLINE_URL;
     }
   }
 
   return memoizedSkylineUrl;
+};
+
+export const __internal = {
+  resetCache() {
+    cachedAssetsBaseHost = undefined;
+    memoizedSkylineUrl = null;
+  },
 };

--- a/src/services/supabase.js
+++ b/src/services/supabase.js
@@ -40,6 +40,21 @@ const buildVersionedName = (baseName, attempt) => {
   return `${namePart}-v${version}${extension}`;
 };
 
+const RESUME_BUCKET = "resumes";
+
+const buildStorageObjectKey = (userId, fileName) => {
+  const trimmedUserId = typeof userId === "string" ? userId.trim() : "";
+  if (!trimmedUserId) {
+    throw new AppError({
+      code: "auth/unauthenticated",
+      message: "Missing user id for storage upload.",
+      hint: "Refresh and sign in again.",
+    });
+  }
+
+  return `${trimmedUserId}/${fileName}`;
+};
+
 const DOCUMENT_MIME_TYPES = new Set([
   "application/pdf",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -123,13 +138,13 @@ export const uploadResumeFile = async (file, { onProgress } = {}) => {
   }
 
   const baseName = cleanBaseName(file?.name || "");
-  const bucket = supabase.storage.from("resumes");
+  const bucket = supabase.storage.from(RESUME_BUCKET);
   const maxAttempts = 5;
   const contentType = resolveContentType(file);
 
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     const candidateName = buildVersionedName(baseName, attempt);
-    const path = `${user.id}/${candidateName}`;
+    const path = buildStorageObjectKey(user.id, candidateName);
 
     const { error } = await bucket.upload(path, file, {
       cacheControl: "3600",
@@ -143,7 +158,7 @@ export const uploadResumeFile = async (file, { onProgress } = {}) => {
     });
 
     if (!error) {
-      return { path, fileName: candidateName, userId: user.id };
+      return { path, fileName: candidateName, userId: user.id, bucket: RESUME_BUCKET };
     }
 
     const status = error?.statusCode ?? error?.status;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -31,6 +31,10 @@
   --panel-border: var(--panel-stroke);
   --panel-highlight: color-mix(in oklab, var(--surface-strong), transparent 42%);
 
+  --hairline-strong: color-mix(in oklab, var(--panel-stroke), transparent 18%);
+  --hairline-soft: color-mix(in oklab, var(--panel-stroke), transparent 46%);
+  --hairline-muted: color-mix(in oklab, var(--panel-stroke), transparent 62%);
+
   --shadow-card-value: 0 20px 60px -40px color-mix(in oklab, var(--emerald-900), transparent 76%);
   --shadow-soft-value: 0 14px 38px -28px color-mix(in oklab, var(--emerald-700), transparent 74%);
   --shadow-lift-value: 0 22px 64px -40px color-mix(in oklab, var(--emerald-900), transparent 70%);
@@ -59,9 +63,13 @@
   --gradient-card: var(--gradient-card-value);
 
   --button-primary-gradient: var(--gradient-primary-value);
+  --button-primary-border: color-mix(in oklab, #fefdfb, transparent 78%);
+  --button-primary-overlay: linear-gradient(135deg, rgba(255, 255, 255, 0.26) 0%, rgba(255, 255, 255, 0.08) 100%);
   --button-primary-shadow: 0 18px 42px -28px color-mix(in oklab, #d946aa, transparent 68%);
   --button-primary-shadow-strong: 0 24px 52px -28px color-mix(in oklab, #c026d3, transparent 62%);
   --button-primary-focus: color-mix(in oklab, #c084fc 60%, #f472b6);
+
+  --hero-overlay-sheen: radial-gradient(circle at 18% 12%, rgba(247, 242, 231, 0.32) 0%, rgba(247, 242, 231, 0) 58%);
 
   --color-primary-400: color-mix(in oklab, var(--accent), transparent 10%);
   --color-primary-500: var(--accent);
@@ -126,6 +134,10 @@
   --panel-border: var(--panel-stroke);
   --panel-highlight: color-mix(in oklab, var(--surface-strong), transparent 32%);
 
+  --hairline-strong: color-mix(in oklab, var(--panel-stroke), transparent 22%);
+  --hairline-soft: color-mix(in oklab, var(--panel-stroke), transparent 48%);
+  --hairline-muted: color-mix(in oklab, var(--panel-stroke), transparent 68%);
+
   --shadow-card-value: 0 20px 56px -36px color-mix(in oklab, var(--emerald-900), transparent 58%);
   --shadow-soft-value: 0 14px 40px -28px color-mix(in oklab, var(--emerald-900), transparent 60%);
   --shadow-lift-value: 0 24px 62px -36px color-mix(in oklab, var(--emerald-900), transparent 54%);
@@ -143,9 +155,13 @@
   );
 
   --button-primary-gradient: var(--gradient-primary-value);
+  --button-primary-border: color-mix(in oklab, #f8fafc, transparent 74%);
+  --button-primary-overlay: linear-gradient(135deg, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0.04) 100%);
   --button-primary-shadow: 0 20px 44px -28px color-mix(in oklab, #ec4899, transparent 60%);
   --button-primary-shadow-strong: 0 26px 52px -28px color-mix(in oklab, #f472b6, transparent 54%);
   --button-primary-focus: color-mix(in oklab, #d8b4fe 55%, #f9a8d4);
+
+  --hero-overlay-sheen: radial-gradient(circle at 26% 10%, rgba(34, 179, 125, 0.24) 0%, rgba(34, 179, 125, 0) 62%);
 }
 
 @keyframes accent-shimmer {


### PR DESCRIPTION
## What changed and why
- cache the Supabase asset host and serve a Saudi gradient fallback so the skyline background stays stable even without env configuration.
- harden the resume upload flow by returning storage metadata, threading it through parsing, and tightening tests around the RLS-safe path handling.
- refresh Saudi Edition styling with new hairline tokens, button overlays, hero treatments, and repositioned bilingual branding.

## Proof
- ⚠️ `npm ci` (fails: npm registry returned 403 for eslint)
- ✅ `npm run lint`
- ✅ `npm run test`
- Lighthouse a11y: not run (CLI unavailable in this container)
- ![Updated Saudi hero](browser:/invocations/xnkvqctf/artifacts/artifacts/hero-saudi-edition.png)

------
https://chatgpt.com/codex/tasks/task_e_68e1b174aae483308c4750abe017cdf5