### PR TITLE
Ensure skyline asset host-only validation is stable

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -28,13 +28,7 @@ export default function Header() {
   const [theme, toggleTheme] = useTheme();
   const isDark = theme === "dark";
   const skylineUrl = useMemo(() => {
-    try {
-      const url = getSkylineUrl();
-      return url;
-    } catch (error) {
-      console.error("Failed to resolve skyline asset", error);
-      return "";
-    }
+    return getSkylineUrl();
   }, []);
   const [skylineLoaded, setSkylineLoaded] = useState(false);
   const [animateSkyline, setAnimateSkyline] = useState(false);
@@ -60,7 +54,7 @@ export default function Header() {
       setSkylineLoaded(true);
     };
     img.onerror = () => {
-      console.error("Failed to load skyline image:", skylineUrl);
+      console.warn("[hero] Failed to load skyline image:", skylineUrl);
       setSkylineLoaded(false);
     };
     img.src = skylineUrl;

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -131,6 +131,24 @@ describe("publicAssetUrl", () => {
     warnSpy.mockRestore();
   });
 
+  it("only emits one warning per invalid base host", async () => {
+    vi.stubEnv(
+      "VITE_ASSETS_BASE_URL",
+      "https://project.supabase.co/storage/v1/object/public/ui-assets",
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { publicAssetUrl, __internal } = await loadModule();
+    const expectedUrl =
+      "https://project.supabase.co/storage/v1/object/public/ui-assets/KAFDH.webp";
+
+    expect(publicAssetUrl("ui-assets", "KAFDH.webp")).toBe(expectedUrl);
+    expect(publicAssetUrl("ui-assets", "KAFDH.webp")).toBe(expectedUrl);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    __internal.resetCache();
+    warnSpy.mockRestore();
+  });
+
   it("falls back to an empty string when neither env is valid", async () => {
     vi.stubEnv("VITE_ASSETS_BASE_URL", "");
     vi.stubEnv("VITE_SUPABASE_URL", "");

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -115,10 +115,20 @@ const isDevEnvironment = () => {
   return false;
 };
 
+const warnedMessages = new Set<string>();
+
 const warnHostOnlyEnv = (message: string) => {
-  if (isDevEnvironment()) {
-    console.warn(message);
+  if (!isDevEnvironment()) {
+    return;
   }
+
+  const normalizedMessage = message.trim();
+  if (warnedMessages.has(normalizedMessage)) {
+    return;
+  }
+
+  warnedMessages.add(normalizedMessage);
+  console.warn(normalizedMessage);
 };
 
 const ensureHostOnlyUrl = (value: string, sourceKey: string) => {
@@ -275,5 +285,6 @@ export const __internal = {
   resetCache() {
     cachedAssetsBaseHost = undefined;
     memoizedSkylineUrl = null;
+    warnedMessages.clear();
   },
 };


### PR DESCRIPTION
## Summary
- deduplicate host-only skyline warning messages and clear caches on reset
- rely on centralized skyline resolution without local try/catch and downgrade load failures to warnings
- extend asset URL tests to cover single-warning behavior for invalid base hosts

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1bad90fb483308573e46d5e388b0f