### PR TITLE
Improve button and icon accessibility

### DIFF
--- a/src/__tests__/Header.test.jsx
+++ b/src/__tests__/Header.test.jsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import Header from "../components/Layout/Header.jsx";
@@ -81,6 +81,18 @@ describe("Header", () => {
 
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+  });
+
+  it("provides accessible labelling for interactive controls and hides decorative icons", () => {
+    const { container } = render(<Header />);
+
+    const themeToggle = screen.getByRole("button", { name: /switch to dark theme/i });
+    expect(themeToggle).toHaveAttribute("title", "Switch to dark theme");
+    expect(themeToggle).toHaveAttribute("aria-pressed");
+
+    container.querySelectorAll("svg").forEach((icon) => {
+      expect(icon).toHaveAttribute("aria-hidden", "true");
+    });
   });
 });
 

--- a/src/__tests__/UploadCard.test.jsx
+++ b/src/__tests__/UploadCard.test.jsx
@@ -21,7 +21,7 @@ describe("UploadCard", () => {
   it("matches snapshot and exposes accessible controls", () => {
     const { container } = render(
       <UploadCard
-        fileName=""
+        fileName="resume.pdf"
         onFileSelect={() => {}}
         onFileClear={() => {}}
         onTextChange={() => {}}
@@ -34,9 +34,13 @@ describe("UploadCard", () => {
       />
     );
 
-    expect(
-      screen.getByRole('button', { name: /upload resume file/i })
-    ).toBeInTheDocument();
+    const dropzone = screen.getByRole("button", { name: /upload resume file/i });
+    expect(dropzone).toBeInTheDocument();
+    expect(dropzone).toHaveAttribute("title", "Upload resume file");
+
+    const removeButton = screen.getByRole("button", { name: /remove selected file/i });
+    expect(removeButton).toHaveAttribute("title", "Remove selected file");
+
     expect(
       screen.getByRole('button', { name: /prepare resume/i })
     ).toBeEnabled();

--- a/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
+++ b/src/__tests__/__snapshots__/UploadCard.test.jsx.snap
@@ -30,6 +30,7 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
       class="relative flex flex-col items-center justify-center gap-3 rounded-[calc(var(--radius-card)_-_0.5rem)] border border-dashed border-[color:color-mix(in_oklab,var(--accent),transparent_36%)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_6%)] px-6 py-12 text-center shadow-[var(--shadow-soft)] transition-[border-color,box-shadow,transform,background-color] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_26%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
       role="button"
       tabindex="0"
+      title="Upload resume file"
     >
       <span
         class="absolute right-6 top-6 inline-flex items-center gap-1 rounded-full border border-[color:var(--hairline-soft)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_10%)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent)]"
@@ -121,6 +122,47 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
       title="Upload resume file"
       type="file"
     />
+    <div
+      class="flex items-center justify-between rounded-2xl border border-[color:var(--hairline-strong)] bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_14%)] px-4 py-3 text-sm text-[color:var(--ink)] shadow-[var(--shadow-soft)] transition-shadow duration-300 ease-[var(--transition-snappy)] dark:text-[color:var(--surface)]"
+    >
+      <span
+        class="truncate font-medium"
+      >
+        resume.pdf
+      </span>
+      <button
+        aria-label="Remove selected file"
+        class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--hairline-soft)] text-[color:var(--accent)] transition-colors hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_16%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_24%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
+        title="Remove selected file"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-circle-x h-4 w-4"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+          <path
+            d="m15 9-6 6"
+          />
+          <path
+            d="m9 9 6 6"
+          />
+        </svg>
+      </button>
+    </div>
     <label
       class="flex flex-col gap-3"
     >
@@ -181,7 +223,6 @@ exports[`UploadCard > matches snapshot and exposes accessible controls 1`] = `
       </button>
       <button
         class="relative inline-flex min-h-[44px] items-center justify-center gap-2 overflow-hidden rounded-2xl px-5 py-2.5 text-sm font-semibold tracking-wide text-[color:var(--ink)] transition-[transform,box-shadow] duration-300 ease-[var(--transition-snappy)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 border border-[color:var(--hairline-strong)] bg-[color:var(--panel-bg)] shadow-[var(--shadow-soft)] before:pointer-events-none before:absolute before:inset-px before:rounded-[inherit] before:bg-[color:color-mix(in_oklab,var(--panel-highlight),transparent_20%)] before:opacity-0 before:transition-opacity before:duration-300 hover:-translate-y-0.5 hover:shadow-[var(--shadow-lift)] hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_8%)] hover:before:opacity-100 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_28%)] focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)] disabled:translate-y-0 disabled:cursor-not-allowed disabled:border-[color:var(--hairline-muted)] disabled:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_32%)] disabled:text-[color:color-mix(in_oklab,var(--ink-muted),transparent_18%)] disabled:shadow-none"
-        disabled=""
       >
         <svg
           aria-hidden="true"

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -247,7 +247,7 @@ export default function Header() {
                 aria-hidden="true"
                 className="absolute -top-8 left-6 text-accent-400 drop-shadow-[0_0_12px_rgba(197,166,106,0.35)]"
               >
-                <Sparkles className="h-7 w-7" />
+                <Sparkles className="h-7 w-7" aria-hidden="true" />
               </span>
               <h1 className="text-balance text-shadow-hero text-4xl font-semibold leading-tight tracking-tight text-[color:var(--surface)] sm:text-5xl lg:text-6xl">
                 AI Resume Optimizer

--- a/src/components/ui/Toast.jsx
+++ b/src/components/ui/Toast.jsx
@@ -59,6 +59,7 @@ export default function Toast({ title, description, type = "info", onDismiss }) 
             onClick={onDismiss}
             className="mt-1 inline-flex h-8 w-8 items-center justify-center rounded-full text-current transition-all duration-[var(--duration-snappy)] ease-[var(--transition-snappy)] hover:bg-surface-50/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary-500 focus-visible:ring-offset-0"
             aria-label="Dismiss notification"
+            title="Dismiss notification"
           >
             <X className="h-4 w-4" aria-hidden="true" />
           </button>

--- a/src/components/ui/UploadCard.jsx
+++ b/src/components/ui/UploadCard.jsx
@@ -167,6 +167,7 @@ export default function UploadCard({
         role="button"
         tabIndex={0}
         aria-label="Upload resume file"
+        title="Upload resume file"
         onClick={() => inputRef.current?.click()}
         onKeyDown={(event) => {
           if (event.key === "Enter" || event.key === " ") {
@@ -218,6 +219,7 @@ export default function UploadCard({
             onClick={onFileClear}
             className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--hairline-soft)] text-[color:var(--accent)] transition-colors hover:bg-[color:color-mix(in_oklab,var(--panel-bg),transparent_16%)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--accent),transparent_24%)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)] dark:focus-visible:ring-offset-[color:var(--surface-strong)]"
             aria-label="Remove selected file"
+            title="Remove selected file"
           >
             <XCircle className="h-4 w-4" aria-hidden="true" />
           </button>


### PR DESCRIPTION
## Summary
- add explicit titles to icon-only controls within the upload card and toast components
- hide decorative hero sparkles from assistive tech while keeping the theme toggle labelled
- extend header and upload card tests to assert accessible names and icon visibility

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1ca2e26708330a31c2d96183deeaa