### PR TITLE
Align hero gradient with main content

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -14,6 +14,7 @@ const saduPattern = encodeURIComponent(
 const containerClass = "app-shell w-full";
 const HERO_HEADER_OFFSET = "4.5rem";
 const heroMinHeightClass = "min-h-[calc(100vh-var(--hero-header-offset,4.5rem))]";
+const heroBackgroundExtentClass = "absolute inset-x-0 top-0 bottom-[-22rem]";
 
 const getPrefersReducedMotion = () => {
   if (typeof window === "undefined") {
@@ -159,14 +160,14 @@ export default function Header() {
   return (
     <header
       className={cn(
-        "hero-bg-animate relative isolate flex flex-col overflow-hidden text-surface-50",
+        "hero-bg-animate relative isolate flex flex-col overflow-visible text-surface-50",
         heroMinHeightClass,
       )}
       style={{ "--hero-header-offset": HERO_HEADER_OFFSET }}
     >
       <div
         className={cn(
-          "relative z-10 flex flex-1 flex-col justify-between gap-8 pb-16 pt-12 sm:gap-12 sm:pb-24 sm:pt-20 lg:pb-28 lg:pt-24",
+          "relative z-10 flex flex-1 flex-col justify-between gap-10 py-16 sm:gap-12 sm:py-20 lg:gap-14 lg:py-24",
           heroMinHeightClass,
         )}
       >
@@ -225,7 +226,7 @@ export default function Header() {
         </div>
 
         <div
-          className={`${containerClass} grid flex-1 items-center gap-10 pb-16 pt-10 sm:gap-12 sm:pt-14 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] lg:gap-16 lg:pb-20 lg:pt-16`}
+          className={`${containerClass} grid flex-1 items-center gap-10 py-12 sm:gap-12 sm:py-14 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] lg:gap-16 lg:py-16`}
         >
           <div
             className={cn(
@@ -370,12 +371,13 @@ export default function Header() {
       {typeof skylineUrl === "string" && skylineUrl ? (
         <>
           {!skylineLoaded && (
-            <div aria-hidden="true" className={skeletonBackgroundClass} />
+            <div aria-hidden="true" className={cn(skeletonBackgroundClass, heroBackgroundExtentClass)} />
           )}
           <div
             aria-hidden="true"
             className={cn(
-              "bg-hero absolute inset-0 -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-300",
+              "bg-hero -z-40 pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-300",
+              heroBackgroundExtentClass,
               !isFallbackSkyline && "md:bg-fixed md:bg-[position:50%_35%]",
               skylineLoaded && animateSkyline ? "skyline-once" : "skyline-still",
               !skylineLoaded && "opacity-0"
@@ -384,12 +386,13 @@ export default function Header() {
           />
         </>
       ) : (
-        <div aria-hidden="true" className={skeletonBackgroundClass} />
+        <div aria-hidden="true" className={cn(skeletonBackgroundClass, heroBackgroundExtentClass)} />
       )}
       <div
         aria-hidden="true"
         className={cn(
-          "absolute inset-0 -z-30 pointer-events-none transition-colors duration-300",
+          "-z-30 pointer-events-none transition-colors duration-300",
+          heroBackgroundExtentClass,
           isDark
             ? "bg-[radial-gradient(circle_at_24%_-6%,color-mix(in_oklab,var(--accent),transparent_82%)_0%,transparent_58%),radial-gradient(circle_at_78%_-16%,color-mix(in_oklab,#8b5cf6,transparent_72%)_0%,transparent_68%),linear-gradient(to_bottom,color-mix(in_oklab,var(--surface),transparent_10%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_52%)_100%)]"
             : "bg-[radial-gradient(circle_at_20%_-10%,color-mix(in_oklab,#a855f7,transparent_78%)_0%,transparent_60%),radial-gradient(circle_at_80%_-14%,color-mix(in_oklab,#ec4899,transparent_82%)_0%,transparent_68%),linear-gradient(to_bottom,color-mix(in_oklab,var(--bg),transparent_06%)_0%,color-mix(in_oklab,var(--surface-strong),transparent_50%)_100%)]",
@@ -397,15 +400,14 @@ export default function Header() {
       />
       <div
         aria-hidden="true"
-        className="absolute inset-0 -z-25 pointer-events-none opacity-80 mix-blend-screen"
+        className={cn("-z-25 pointer-events-none opacity-80 mix-blend-screen", heroBackgroundExtentClass)}
         style={{ backgroundImage: "var(--hero-overlay-sheen)" }}
       />
       <div
-        className="absolute inset-0 -z-20 opacity-[0.08] mix-blend-soft-light"
+        className={cn("-z-20 opacity-[0.08] mix-blend-soft-light", heroBackgroundExtentClass)}
         style={{ backgroundImage: `url("data:image/svg+xml,${saduPattern}")`, backgroundSize: "260px" }}
         aria-hidden="true"
       />
-      <div className="accent-divider absolute inset-x-0 bottom-0 -z-10 h-px" aria-hidden="true" />
     </header>
   );
 }

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -507,10 +507,10 @@ export default function MainContent() {
   return (
     <main
       data-app-main
-      className="relative isolate z-20 min-h-screen pb-24 pt-20 sm:pb-32 sm:pt-28 lg:pb-40 lg:pt-32 before:absolute before:inset-x-0 before:top-0 before:-z-10 before:h-full before:bg-gradient-to-b before:from-transparent before:via-sand-50/70 before:to-sand-50/95 before:content-[''] before:pointer-events-none dark:before:via-zinc-900/50 dark:before:to-zinc-950/85"
+      className="relative isolate z-20 min-h-screen pb-24 pt-8 sm:pb-32 sm:pt-12 lg:pb-40 lg:pt-16"
     >
       <ToastContainer>{renderedToasts}</ToastContainer>
-      <div className={`${containerClass} space-y-7 text-ink-700 sm:space-y-10 lg:space-y-12 dark:text-surface-50`}>
+      <div className={`${containerClass} space-y-8 text-ink-700 sm:space-y-12 lg:space-y-16 dark:text-surface-50`}>
         <div className="card-glow rounded-[var(--radius-card)] border border-secondary-500/12 bg-sand-50/95 p-6 shadow-card backdrop-blur-sm transition-shadow duration-[var(--duration-breathe)] ease-[var(--transition-snappy)] hover:shadow-[0_24px_70px_-42px_rgba(15,15,18,0.58)] sm:p-8 sm:backdrop-blur-xl lg:p-9 dark:border-surface-50/12 dark:bg-zinc-900/60">
           {flowProgress > 0 && (
             <div className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-smoke-50/70 dark:bg-zinc-900/50">


### PR DESCRIPTION
## Summary
- extend the hero background layers so the skyline gradient flows behind the first feature section
- remove the extra main-section gradient wrapper and tighten section spacing to use the shared rhythm scale

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e2634cead8833099aae9eaef4594ca