### PR TITLE
Fix match analysis score normalization and add regression test

### DIFF
--- a/src/__tests__/matchScore.fixture.test.js
+++ b/src/__tests__/matchScore.fixture.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { analyzeResume } from "../services/api";
+
+const mockResponse = (payload) => ({
+  ok: true,
+  json: vi.fn().mockResolvedValue(payload),
+});
+
+describe("analyzeResume", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("clamps and returns non-zero scores when API responds with numeric strings", async () => {
+    const payload = {
+      score: "82.4",
+      coverage: "0.45",
+      similarity: "0.61",
+      missing_keywords: ["python"],
+      matched_keywords: ["react"],
+    };
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(mockResponse(payload));
+
+    const result = await analyzeResume(
+      { plainText: "Experienced React engineer" },
+      "React developer role",
+    );
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(result.score).toBe(82);
+    expect(result.coverage).toBeCloseTo(0.45, 2);
+    expect(result.cosine).toBeCloseTo(0.61, 2);
+    expect(result.missingKeywords).toContain("python");
+  });
+});

--- a/src/components/Features/JobMatch.jsx
+++ b/src/components/Features/JobMatch.jsx
@@ -42,6 +42,7 @@ export default function JobMatch({
   matchAnalysis,
   isAnalyzing = false,
   hasResume = false,
+  onToast,
 }) {
   const [jobText, setJobText] = useState(() => {
     if (typeof window === "undefined") {
@@ -60,14 +61,23 @@ export default function JobMatch({
     }
   }, [jobText]);
 
+  const notify = onToast ?? null;
+
   const handleAnalyze = async () => {
-    if (!jobText.trim()) {
-      setError("Paste the job description before analyzing.");
+    const trimmedJob = jobText.trim();
+    if (!trimmedJob) {
+      const message = "Paste the job description before analyzing.";
+      setError(message);
+      notify?.({
+        type: "warning",
+        title: "Job description needed",
+        description: "Paste the job description before analyzing the match.",
+      });
       return;
     }
     setError("");
     try {
-      await onAnalyzeMatch(jobText);
+      await onAnalyzeMatch(trimmedJob);
     } catch (err) {
       setError(err?.message || "We could not analyze this match.");
     }

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -477,6 +477,7 @@ export default function MainContent() {
             matchAnalysis={matchAnalysis}
             isAnalyzing={isAnalyzing}
             hasResume={Boolean(resumeData?.plainText)}
+            onToast={pushToast}
           />
         )}
         {activeTab === "optimize" && (

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -10,6 +10,24 @@ const PARSE_ENDPOINT = `${FUNCTION_BASE_PATH}/parse-resume`;
 const REQUEST_TIMEOUT = 15000;
 const OPTIMIZATION_TIMEOUT = 45000;
 
+const clampScore = (value) => {
+  const numeric = Number.parseFloat(value);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+  return Math.min(100, Math.max(0, Math.round(numeric)));
+};
+
+const clampRatio = (value) => {
+  const numeric = Number.parseFloat(value);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+  if (numeric <= 0) return 0;
+  if (numeric >= 1) return 1;
+  return numeric;
+};
+
 const sanitize = (value) => {
   let buffer = "";
   for (const char of value) {
@@ -371,15 +389,16 @@ export const analyzeResume = async (resumeInput, jobText, options = {}) => {
     const topHits = Array.isArray(data?.matched_keywords)
       ? data.matched_keywords.map((item) => sanitize(String(item))).filter(Boolean)
       : [];
-    const coverage = Number(data?.coverage ?? 0);
-    const cosine = Number(data?.similarity ?? 0);
+    const coverage = clampRatio(data?.coverage);
+    const cosine = clampRatio(data?.similarity);
+    const score = clampScore(data?.score);
 
     const suggestions = topMissing.slice(0, 6).map(
       (keyword) => `Consider highlighting “${keyword}” to better reflect the role requirements.`,
     );
 
     const baseResult = {
-      score: Number.isFinite(data?.score) ? Math.round(data.score) : 0,
+      score,
       missingKeywords: topMissing.slice(0, 12),
       suggestions,
       topHits: topHits.slice(0, 12),


### PR DESCRIPTION
## Summary
- ensure match analysis normalizes numeric strings and clamps scores/ratios before returning results
- surface a warning toast from JobMatch when the job description input is empty and forward the toast handler from MainContent
- add a regression fixture test to prove analyzeResume returns a non-zero score for valid inputs

## Testing
- npm ci
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e43dd4228c8330ae3fc8da17ab9561