### PR TITLE
Improve mobile hero stability and resume parsing heuristics

### DIFF
--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -13,7 +13,9 @@ const saduPattern = encodeURIComponent(
 
 const containerClass = "app-shell w-full";
 const HERO_HEADER_OFFSET = "4.5rem";
-const heroBackgroundExtentClass = "absolute inset-x-0 top-0 bottom-[-64rem]";
+const heroBackgroundExtentClass =
+  "absolute inset-x-0 top-0 h-[120dvh] max-h-[1100px] md:h-auto md:bottom-[-64rem]";
+const MOBILE_GUTTER_VALUE = "clamp(0.55rem, 2.8vw, 1.35rem)";
 
 const getPrefersReducedMotion = () => {
   if (typeof window === "undefined") {
@@ -53,6 +55,42 @@ export default function Header() {
   const [workflowVisible, setWorkflowVisible] = useState(initialReducedMotion);
   const heroAnimatedRef = useRef(initialReducedMotion);
   const workflowAnimatedRef = useRef(initialReducedMotion);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const root = document.documentElement;
+    const mediaQuery = window.matchMedia("(max-width: 560px)");
+
+    const applyGutter = (matches) => {
+      if (matches) {
+        root.style.setProperty("--app-shell-gutter", MOBILE_GUTTER_VALUE);
+      } else {
+        root.style.removeProperty("--app-shell-gutter");
+      }
+    };
+
+    applyGutter(mediaQuery.matches);
+
+    const listener = (event) => applyGutter(event.matches);
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", listener);
+    } else if (typeof mediaQuery.addListener === "function") {
+      mediaQuery.addListener(listener);
+    }
+
+    return () => {
+      root.style.removeProperty("--app-shell-gutter");
+      if (typeof mediaQuery.removeEventListener === "function") {
+        mediaQuery.removeEventListener("change", listener);
+      } else if (typeof mediaQuery.removeListener === "function") {
+        mediaQuery.removeListener(listener);
+      }
+    };
+  }, []);
 
   // Debug state changes
   useEffect(() => {
@@ -409,15 +447,15 @@ export default function Header() {
             aria-label="Decorative skyline background"
             title="Saudi Arabia skyline"
             className={cn(
-              "bg-hero pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-300 absolute print:opacity-100",
+              "bg-hero pointer-events-none bg-cover bg-center bg-no-repeat transition-[opacity,transform] duration-300 absolute overflow-hidden print:opacity-100",
               heroBackgroundExtentClass,
               skylineLoaded && animateSkyline ? "skyline-once" : "skyline-still",
-              skylineLoaded ? "opacity-100" : "opacity-0"
+              skylineLoaded ? "opacity-100" : "opacity-90"
             )}
-            style={{ 
+            style={{
               backgroundImage: `url('${skylineUrl}')`,
-              backgroundPosition: '50% 35%',
-              zIndex: -40
+              backgroundPosition: "50% 35%",
+              zIndex: -40,
             }}
             ref={(el) => {
               if (el && skylineLoaded) {
@@ -426,7 +464,17 @@ export default function Header() {
                 console.log("[hero] Computed opacity:", window.getComputedStyle(el).opacity);
               }
             }}
-          />
+          >
+            <img
+              src={skylineUrl}
+              alt=""
+              aria-hidden="true"
+              loading="lazy"
+              decoding="async"
+              className="absolute inset-0 h-full w-full object-cover"
+              style={{ filter: "saturate(1.12) brightness(1.08)", opacity: 0.95 }}
+            />
+          </div>
         </>
       ) : (
         <div aria-hidden="true" className={cn(skeletonBackgroundClass, heroBackgroundExtentClass)} />
@@ -443,8 +491,8 @@ export default function Header() {
       />
       <div
         aria-hidden="true"
-        className={cn("-z-25 pointer-events-none opacity-80 mix-blend-screen", heroBackgroundExtentClass)}
-        style={{ backgroundImage: "var(--hero-overlay-sheen)" }}
+        className={cn("-z-25 pointer-events-none mix-blend-screen", heroBackgroundExtentClass)}
+        style={{ backgroundImage: "var(--hero-overlay-sheen)", opacity: isDark ? 0.5 : 0.68 }}
       />
       <div
         className={cn("-z-20 opacity-[0.08] mix-blend-soft-light", heroBackgroundExtentClass)}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -45,6 +45,63 @@ const tokenize = (input) =>
     .match(/[a-z0-9]+/g)
     ?.filter((token) => !STOPWORDS.has(token) && token.length > 2) ?? [];
 
+const GENERIC_JOB_TOKENS = new Set([
+  "candidate",
+  "career",
+  "description",
+  "experience",
+  "job",
+  "opportunity",
+  "profile",
+  "resume",
+  "role",
+  "some",
+  "summary",
+]);
+
+const buildTokenOverlap = (resumeText, jobDesc) => {
+  const resumeTokens = new Set(tokenize(resumeText));
+  const jobTokens = tokenize(jobDesc);
+  if (jobTokens.length === 0 || resumeTokens.size === 0) {
+    return {
+      uniqueJobTokens: [],
+      matchedTokens: [],
+      missingTokens: [],
+    };
+  }
+
+  const uniqueJobTokens = Array.from(new Set(jobTokens));
+  const informativeTokens = uniqueJobTokens.filter((token) => !GENERIC_JOB_TOKENS.has(token));
+  if (informativeTokens.length === 0) {
+    return { uniqueJobTokens: [], matchedTokens: [], missingTokens: [] };
+  }
+
+  const matchedTokens = informativeTokens.filter((token) => resumeTokens.has(token));
+  const missingTokens = informativeTokens.filter((token) => !resumeTokens.has(token));
+
+  return { uniqueJobTokens: informativeTokens, matchedTokens, missingTokens };
+};
+
+const buildFallbackMatch = (resumeText, jobDesc) => {
+  const { uniqueJobTokens, matchedTokens, missingTokens } = buildTokenOverlap(resumeText, jobDesc);
+  if (uniqueJobTokens.length === 0) {
+    return null;
+  }
+
+  const coverage = matchedTokens.length / uniqueJobTokens.length;
+  const cosine = coverage > 0 ? Math.min(1, Math.sqrt(coverage)) : 0;
+  const baseScore = 32 + coverage * 58;
+  const score = Math.round(Math.min(94, Math.max(22, baseScore)));
+
+  return {
+    coverage,
+    cosine,
+    score,
+    missingKeywords: missingTokens.slice(0, 12),
+    matchedKeywords: matchedTokens.slice(0, 12),
+  };
+};
+
 const pickKeywords = (jobDesc, resumeText) => {
   const jobTokens = tokenize(jobDesc);
   const resumeTokens = new Set(tokenize(resumeText));
@@ -383,15 +440,30 @@ export const analyzeResume = async (resumeInput, jobText, options = {}) => {
     });
 
     const data = await handleResponse(response);
-    const topMissing = Array.isArray(data?.missing_keywords)
+    const topMissingRaw = Array.isArray(data?.missing_keywords)
       ? data.missing_keywords.map((item) => sanitize(String(item))).filter(Boolean)
       : [];
-    const topHits = Array.isArray(data?.matched_keywords)
+    const topHitsRaw = Array.isArray(data?.matched_keywords)
       ? data.matched_keywords.map((item) => sanitize(String(item))).filter(Boolean)
       : [];
-    const coverage = clampRatio(data?.coverage);
-    const cosine = clampRatio(data?.similarity);
-    const score = clampScore(data?.score);
+    const coverageResponse = clampRatio(data?.coverage);
+    const cosineResponse = clampRatio(data?.similarity);
+    const scoreResponse = clampScore(data?.score);
+
+    const fallback = buildFallbackMatch(resume, job);
+    const shouldFallback =
+      fallback &&
+      fallback.coverage > 0 &&
+      ((scoreResponse === 0 && coverageResponse === 0 && cosineResponse === 0) ||
+        (coverageResponse === 0 && fallback.coverage > 0.05));
+
+    const coverage = shouldFallback ? fallback.coverage : coverageResponse;
+    const cosine = shouldFallback ? fallback.cosine : cosineResponse;
+    const score = shouldFallback ? fallback.score : scoreResponse;
+    const fallbackMissing = fallback?.missingKeywords ?? [];
+    const fallbackHits = fallback?.matchedKeywords ?? [];
+    const topMissing = topMissingRaw.length > 0 ? topMissingRaw : fallbackMissing;
+    const topHits = topHitsRaw.length > 0 ? topHitsRaw : fallbackHits;
 
     const suggestions = topMissing.slice(0, 6).map(
       (keyword) => `Consider highlighting “${keyword}” to better reflect the role requirements.`,

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -81,6 +81,32 @@ describe('analyzeResume', () => {
     });
   });
 
+  it('falls back to keyword overlap scoring when API returns zeros', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          score: 0,
+          coverage: 0,
+          similarity: 0,
+          missing_keywords: [],
+          matched_keywords: [],
+        }),
+    });
+
+    const resume = {
+      plainText:
+        'Senior data analyst skilled in SQL, Tableau dashboards, and financial reporting for Riyadh banking clients.',
+    };
+
+    const result = await analyzeResume(resume, 'Looking for a data analyst with SQL and Tableau experience.');
+
+    expect(result.score).toBeGreaterThan(20);
+    expect(result.coverage).toBeGreaterThan(0);
+    expect(result.missingKeywords.length).toBeGreaterThan(0);
+    expect(result.topHits).toContain('sql');
+  });
+
   it('throws a timeout error when aborted', async () => {
     const abortError = new Error('Aborted');
     abortError.name = 'AbortError';

--- a/src/services/exportPdf.js
+++ b/src/services/exportPdf.js
@@ -15,7 +15,46 @@ const SECTION_KEYWORDS = {
   projects: ["projects", "selected projects", "key projects", "portfolio"],
 };
 
-const normalize = (value) => value.replace(/\s+/g, " ").trim();
+const NON_TEXT_PATTERN = /[^\p{L}\p{N}\p{P}\p{Zs}]/gu;
+const DIACRITIC_PATTERN = /\p{Diacritic}/gu;
+
+const stripControlCharacters = (value) => {
+  let sanitized = "";
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if ((code >= 0 && code <= 31) || (code >= 127 && code <= 159) || char === "\u2028" || char === "\u2029") {
+      sanitized += " ";
+    } else {
+      sanitized += char;
+    }
+  }
+  return sanitized;
+};
+
+const normalize = (value) => {
+  const withoutDiacritics = value.normalize("NFKD").replace(DIACRITIC_PATTERN, "");
+  return stripControlCharacters(withoutDiacritics.normalize("NFKC"))
+    .replace(NON_TEXT_PATTERN, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const isMeaningfulLine = (line) => {
+  if (!line) {
+    return false;
+  }
+  const compact = line.replace(/\s+/g, "");
+  if (compact.length === 0) {
+    return false;
+  }
+  const letters = compact.match(/\p{L}/gu)?.length ?? 0;
+  const digits = compact.match(/\p{N}/gu)?.length ?? 0;
+  const informative = letters + digits;
+  if (compact.length <= 4) {
+    return informative > 0;
+  }
+  return informative / compact.length >= 0.25;
+};
 
 const detectHeading = (line) => {
   const normalized = line.toLowerCase().replace(/[:.]+$/, "");
@@ -30,11 +69,13 @@ const splitLines = (text) =>
   text
     .split(/\r?\n/)
     .map((line) => normalize(line))
-    .filter(Boolean);
+    .filter(isMeaningfulLine);
 
 const sanitizeLines = (items) =>
   Array.isArray(items)
-    ? items.map((item) => normalize(String(item ?? ""))).filter(Boolean)
+    ? items
+        .map((item) => normalize(String(item ?? "")))
+        .filter(isMeaningfulLine)
     : [];
 
 const ensureResumeDocument = (input) => {
@@ -459,7 +500,11 @@ const triggerPrint = (html) => {
 };
 
 const normalizeVariant = (variant = "styled") => {
-  if (variant === "ats" || variant === "ats-plain") {
+  if (typeof variant !== "string") {
+    return "styled";
+  }
+  const normalized = variant.trim().toLowerCase();
+  if (["ats", "ats-plain", "ats_safe", "ats-safe", "plain", "plain-ats"].includes(normalized)) {
     return "ats-plain";
   }
   return "styled";

--- a/src/services/exportPdf.test.js
+++ b/src/services/exportPdf.test.js
@@ -74,11 +74,27 @@ Vision 2030 Dashboard – Built analytics portal for executive leadership.`;
     expect(html).toContain("AI Suggestions");
   });
 
+  it("removes noisy glyphs before exporting", () => {
+    const noisyResume = `John Doe\nÿå§×ñ Contact\nSUMMARY\nDriven leader\nEXPERIENCE\n• Built Riyadh data platform`;
+    const sections = deriveResumeSections(noisyResume);
+    expect(sections.contactLines[0]).toBe("John Doe");
+    expect(sections.contactLines).not.toContain(expect.stringContaining("ÿ"));
+    const html = buildPlainExportHtml({
+      resumeDocument: { plainText: noisyResume },
+      jobDescription: "Data platform lead",
+      matchAnalysis: { score: 0, coverage: 0, cosine: 0 },
+      optimizations: [],
+    });
+    expect(html).not.toContain("ÿ");
+  });
+
   it("normalizes export variant aliases", () => {
     expect(normalizeVariant()).toBe("styled");
     expect(normalizeVariant("styled")).toBe("styled");
     expect(normalizeVariant("ats")).toBe("ats-plain");
     expect(normalizeVariant("ats-plain")).toBe("ats-plain");
+    expect(normalizeVariant("ATS_SAFE")).toBe("ats-plain");
+    expect(normalizeVariant("plain")).toBe("ats-plain");
     expect(normalizeVariant("unknown")).toBe("styled");
   });
 


### PR DESCRIPTION
## Summary
- keep the hero skyline visible during mobile captures by widening the stacking backdrop, rendering the image inline, and relaxing the overlay while tightening mobile gutters
- sanitize resume exports by stripping control characters/diacritics, filtering noisy lines, and normalizing ATS template aliases
- add keyword-overlap fallbacks so sparse job descriptions return realistic scores and extend coverage tests accordingly

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e58df169b48330811631650e084f2f