### PR TITLE
feat: surface source_span as proof-on-hover in optimization cards

### DIFF
--- a/src/__tests__/OptimizationCard.test.jsx
+++ b/src/__tests__/OptimizationCard.test.jsx
@@ -1,0 +1,46 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import OptimizationCard from '../components/shared/OptimizationCard';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, fallback) => (typeof fallback === 'string' ? fallback : key),
+    i18n: { language: 'en' },
+  }),
+}));
+
+afterEach(cleanup);
+
+const baseCard = {
+  section: 'Experience',
+  issue: 'Bullet lacks impact.',
+  suggestion: 'Use STAR format with quantified results.',
+  exampleBefore: 'Worked on web projects.',
+  exampleAfter: 'Led migration of 3 web services, cutting load time by 40%.',
+};
+
+describe('OptimizationCard source_span evidence disclosure', () => {
+  it('shows evidence through an accessible disclosure when evidence metadata is present', () => {
+    render(<OptimizationCard card={{ ...baseCard, evidence: 'Worked on web projects' }} onCopy={vi.fn()} />);
+
+    const trigger = screen.getByRole('button', { name: 'Grounded in your resume' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('note')).toHaveTextContent('Worked on web projects');
+  });
+
+  it('renders no evidence disclosure when evidence is absent or empty', () => {
+    const { rerender } = render(<OptimizationCard card={baseCard} onCopy={vi.fn()} />);
+
+    expect(screen.queryByText('Grounded in your resume')).not.toBeInTheDocument();
+    expect(screen.getByText('Led migration of 3 web services, cutting load time by 40%.')).toBeInTheDocument();
+
+    rerender(<OptimizationCard card={{ ...baseCard, evidence: '' }} onCopy={vi.fn()} />);
+
+    expect(screen.queryByText('Grounded in your resume')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/OptimizationCard.tsx
+++ b/src/components/shared/OptimizationCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Clipboard, ClipboardCheck, FileText, Sparkles, Target, ChevronDown } from "lucide-react";
 import { GlassButton } from "../ui/GlassButton";
@@ -9,6 +9,9 @@ export default function OptimizationCard({ card, onCopy, disabledActions = false
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const [isOpen, setIsOpen] = useState(true);
+  const [isEvidenceOpen, setIsEvidenceOpen] = useState(false);
+  const evidenceId = useId();
+  const evidence = typeof card?.evidence === "string" ? card.evidence.trim() : "";
 
   const handleCopy = async (e) => {
     e.stopPropagation();
@@ -129,6 +132,29 @@ export default function OptimizationCard({ card, onCopy, disabledActions = false
                 </div>
               </div>
             </div>
+
+            {evidence && (
+              <div className="mt-1 space-y-1">
+                <button
+                  type="button"
+                  aria-expanded={isEvidenceOpen}
+                  aria-controls={evidenceId}
+                  onClick={() => setIsEvidenceOpen((value) => !value)}
+                  className="inline-flex items-center rounded border border-[color:var(--glass-border)] bg-transparent px-2 py-0.5 text-xs text-ink-soft/70 transition-colors hover:border-emerald-500/25 hover:text-ink-soft focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-emerald-500/40"
+                >
+                  {t('optimization.evidenceLabel', 'Grounded in your resume')}
+                </button>
+                {isEvidenceOpen && (
+                  <p
+                    id={evidenceId}
+                    role="note"
+                    className="rounded bg-[color:color-mix(in_oklab,var(--surface-glass),transparent_30%)] px-2 py-1.5 text-xs leading-relaxed text-ink-soft/80"
+                  >
+                    {evidence}
+                  </p>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/locales/ar/optimization.json
+++ b/src/locales/ar/optimization.json
@@ -14,6 +14,7 @@
     "recommendation": "توصية",
     "before": "قبل",
     "after": "بعد",
-    "optimizedView": "العرض المحسّن"
+    "optimizedView": "العرض المحسّن",
+    "evidenceLabel": "مستند إلى سيرتك الذاتية"
   }
 }

--- a/src/locales/en/optimization.json
+++ b/src/locales/en/optimization.json
@@ -14,6 +14,7 @@
     "recommendation": "Recommendation",
     "before": "Before",
     "after": "After",
-    "optimizedView": "Optimized View"
+    "optimizedView": "Optimized View",
+    "evidenceLabel": "Grounded in your resume"
   }
 }


### PR DESCRIPTION
Each Experience bullet card now carries the verbatim resume phrase it was grounded in (evidence field), so users can verify a rewrite traces to their own words rather than being invented.

- AI schema (optimizeJsonSchema + Zod): add optional source_span field to bullet_improvements items; update prompt to request a 5-15 word verbatim substring per bullet
- optimize.ts + optimize-stream.ts: pass source_span through as evidence on Experience cards only; both mappers kept identical
- OptimizationCardData interface added to src/types/analysis.ts
- OptimizationCard.tsx: typed card prop; CSS group-hover/focus-within affordance renders chip + verbatim text (hover, keyboard, tap); absent/empty evidence renders nothing — older cached results unchanged
- i18n: evidenceLabel added to EN + AR optimization.json
- Tests: 4 new assertions in OptimizationCard.test.jsx