### PR TITLE
First-run gate for Path B (no-CV) onboarding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import { TermsOfService } from "./pages/TermsOfService";
 import { AdminFeedbackPage } from "./pages/AdminFeedbackPage";
 import { HRSuperSaudOverlay, HRSuperSaudProvider } from "./features/hr-super-saud";
 import { useResumeStore } from "./lib/stores/resumeStore";
+import OnboardingChat from "./components/onboarding/OnboardingChat";
+import { isOnboarded, markOnboarded } from "./lib/onboarding/onboardedFlag";
 
 const getCurrentPath = () => {
   if (typeof window === "undefined") return "/";
@@ -26,6 +28,12 @@ const getCurrentPath = () => {
 export default function App() {
   const [currentPath, setCurrentPath] = useState(getCurrentPath);
   const hasResume = useResumeStore((state) => Boolean(state.originalResume || state.parsedResumeText));
+  const hasSearchIntent = useResumeStore((state) => Boolean(state.searchIntent));
+
+  // First-run onboarding gate (profile state, not device). The localStorage flag
+  // breaks the loop for a user who skips every slot (no resume + no intent).
+  const [onboardedFlag, setOnboardedFlag] = useState(isOnboarded);
+  const needsOnboarding = !hasResume && !hasSearchIntent && !onboardedFlag;
 
   // Run storage migration once on app initialization
   useEffect(() => {
@@ -67,6 +75,13 @@ export default function App() {
               <TermsOfService />
             ) : currentPath === "/admin/feedback" ? (
               <AdminFeedbackPage />
+            ) : needsOnboarding ? (
+              <OnboardingChat
+                onComplete={() => {
+                  markOnboarded();
+                  setOnboardedFlag(true);
+                }}
+              />
             ) : (
               <MainContent />
             )}

--- a/src/__tests__/App.navigation.test.tsx
+++ b/src/__tests__/App.navigation.test.tsx
@@ -142,6 +142,8 @@ describe('App compliance navigation', () => {
   beforeEach(() => {
     setPath('/');
     headerProps.calls.length = 0;
+    // Returning user: skip the first-run onboarding gate so the workspace renders.
+    window.localStorage.setItem('watheq:onboarded', 'true');
   });
 
   it('renders workspace for the default app path', () => {

--- a/src/__tests__/App.onboarding.test.tsx
+++ b/src/__tests__/App.onboarding.test.tsx
@@ -3,6 +3,11 @@ import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import App from '../App';
+import { useResumeStore } from '../lib/stores/resumeStore';
+
+vi.mock('../components/onboarding/OnboardingChat', () => ({
+  default: () => <main>Onboarding</main>,
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -100,6 +105,8 @@ describe('App onboarding overlay — react-joyride removed', () => {
 
   beforeEach(() => {
     setPath('/');
+    // These assert the workspace (joyride-removal); skip the first-run gate.
+    window.localStorage.setItem('watheq:onboarded', 'true');
   });
 
   afterEach(() => {
@@ -137,6 +144,16 @@ describe('App onboarding overlay — react-joyride removed', () => {
     const uploadButton = screen.getByRole('button', { name: /upload resume/i });
     expect(uploadButton).toBeInTheDocument();
     expect(uploadButton).toBeEnabled();
+  });
+
+  it('shows the first-run onboarding gate when no resume, no intent, and not flagged', () => {
+    window.localStorage.removeItem('watheq:onboarded');
+    useResumeStore.setState({ originalResume: null, parsedResumeText: null, searchIntent: null });
+
+    render(<App />);
+
+    expect(screen.getByText('Onboarding')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /upload resume/i })).toBeNull();
   });
 
   it('keeps workflow controls present and clickable after sign-in', () => {

--- a/src/lib/onboarding/onboardedFlag.ts
+++ b/src/lib/onboarding/onboardedFlag.ts
@@ -1,0 +1,23 @@
+// src/lib/onboarding/onboardedFlag.ts
+// One-time "user has seen onboarding" flag. Breaks the first-run gate loop for the
+// lazy user who skips every slot (no resume + no intent would otherwise keep
+// needsOnboarding true forever). Storage key uses the watheq: prefix.
+const ONBOARDED_KEY = 'watheq:onboarded';
+
+export function isOnboarded(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(ONBOARDED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function markOnboarded(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(ONBOARDED_KEY, 'true');
+  } catch {
+    // Private mode / storage disabled — gate falls back to resume/intent presence.
+  }
+}


### PR DESCRIPTION
Stacked on #114. Small, isolated gate (4 files).

## What
Renders `OnboardingChat` as a first-run wrapper before the workspace — **no route**, gated on profile state, not device:

```
needsOnboarding = !hasResume && !hasSearchIntent && !flag('watheq:onboarded')
```

- Wired in `src/App.tsx` on the non-static main branch only
- `onboardedFlag` helper (`watheq:onboarded`) breaks the loop for a user who skips every slot
- Static paths (`/privacy`, `/terms`, `/admin/feedback`) and returning users bypass
- New gate test; existing `App` render tests opt out via the flag

## Known gap (intentional — do not close item 1)
Only fires when `!hasResume`, so **upload-first (Path A) users are never asked role/comp/location** and `searchIntent` stays empty for them — which disables the optimize injection for the majority. Path-A inline intent capture is the next PR. Item 1 ships only after that lands.

## Verification
`npm run quality:parallel` green: 110 files / 955 tests pass (incl. new gate test), lint + types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
