### PR TITLE
Path-A inline intent capture (post-upload)

### DIFF
--- a/src/__tests__/MainContent.test.jsx
+++ b/src/__tests__/MainContent.test.jsx
@@ -1,6 +1,7 @@
-import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import MainContent from "../components/Layout/MainContent";
+import { useResumeStore } from "../lib/stores/resumeStore";
 
 const {
   parseResumeMock,
@@ -10,6 +11,7 @@ const {
   analyzeResumeTruthCheckMock,
   generateClarificationsMock,
   extractJobMetadataMock,
+  onboardExtractMock,
   analyticsMock,
 } = vi.hoisted(() => ({
   parseResumeMock: vi.fn(),
@@ -17,6 +19,7 @@ const {
   optimizeResumeMock: vi.fn(),
   optimizeResumeStreamMock: vi.fn(),
   analyzeResumeTruthCheckMock: vi.fn(),
+  onboardExtractMock: vi.fn(),
   // Non-fatal: always returns empty clarifications in tests so the optimize flow proceeds directly
   generateClarificationsMock: vi.fn().mockResolvedValue({ clarifications: [] }),
   extractJobMetadataMock: vi.fn(() => Promise.resolve(null)),
@@ -191,6 +194,7 @@ vi.mock("../services/api.js", () => ({
   analyzeResumeTruthCheck: analyzeResumeTruthCheckMock,
   generateClarifications: generateClarificationsMock,
   extractJobMetadata: extractJobMetadataMock,
+  onboardExtract: onboardExtractMock,
   AI_DEFAULT_TEMPERATURE: 0.32,
   isAuthRequiredError: (error) =>
     error?.type === "AUTH_REQUIRED" || error?.code === "auth/required" || error?.status === 401,
@@ -228,6 +232,11 @@ describe("MainContent resume parsing", () => {
     extractJobMetadataMock.mockResolvedValue(null);
     generateClarificationsMock.mockReset();
     generateClarificationsMock.mockResolvedValue({ clarifications: [] });
+    onboardExtractMock.mockReset();
+    onboardExtractMock.mockResolvedValue({ value: {}, confidence: "low" });
+    // Path-A inline panel gates on the store — reset so it only appears where a test
+    // opts in by setting originalResume.
+    useResumeStore.setState({ originalResume: null, searchIntent: null });
     Object.values(analyticsMock).forEach((mock) => mock.mockClear());
     parseResumeMock.mockResolvedValue({
       plainText: "Parsed resume",
@@ -705,5 +714,51 @@ describe("MainContent resume parsing", () => {
     expect(screen.getAllByText(/Vision 2030/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/tabs\.bulk/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Pipeline/i).length).toBeGreaterThan(0);
+  });
+
+  it("keeps the Path-A intent panel mounted across role -> comp -> location, then unmounts on complete", async () => {
+    // Signed-in user, freshly parsed resume in the store, no intent yet, prompt unseen.
+    localStorage.setItem("watheq:lastActiveTab", "resume");
+    localStorage.setItem("watheq:resumeData", JSON.stringify({ plainText: "Parsed resume", basics: { name: "Sara Al-Otaibi" }, sections: [] }));
+    useResumeStore.setState({
+      originalResume: {
+        basics: { name: "Sara Al-Otaibi", label: "", email: "", phone: "", summary: "", location: { city: "", countryCode: "", region: "" }, profiles: [] },
+        work: [],
+        education: [],
+        skills: [],
+      },
+      searchIntent: null,
+    });
+    onboardExtractMock.mockResolvedValue({ value: { targetRoles: ["Frontend Engineer"] }, confidence: "high" });
+
+    render(<MainContent />);
+
+    // role slot is shown (cv_basics skipped inline)
+    expect(await screen.findByText("What role are you targeting?")).toBeInTheDocument();
+
+    // Answer role — this writes searchIntent. The panel must NOT unmount (the bug).
+    fireEvent.change(screen.getByPlaceholderText(/senior frontend engineer/i), {
+      target: { value: "Frontend Engineer" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
+
+    // comp slot appears -> panel stayed mounted even though intent is now non-empty.
+    expect(await screen.findByText("What salary are you after?")).toBeInTheDocument();
+    expect(useResumeStore.getState().searchIntent?.targetRoles).toEqual(["Frontend Engineer"]);
+
+    // comp via chip -> location
+    fireEvent.click(screen.getByRole("button", { name: /10.15k SAR\/mo/i }));
+    expect(await screen.findByText("Where do you want to work?")).toBeInTheDocument();
+
+    // location via chip -> final slot resolved -> onComplete -> panel unmounts
+    fireEvent.click(screen.getByRole("button", { name: /^remote$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Where do you want to work?")).not.toBeInTheDocument();
+    });
+    expect(localStorage.getItem("watheq:intentPrompted")).toBe("true");
+    const intent = useResumeStore.getState().searchIntent;
+    expect(intent?.compRange).toBeTruthy();
+    expect(intent?.location?.workMode).toBe("remote");
   });
 });

--- a/src/components/Layout/MainContent.tsx
+++ b/src/components/Layout/MainContent.tsx
@@ -22,6 +22,8 @@ import {
 import { useAuth } from "../../hooks/useAuth";
 import UploadSection from "../sections/UploadSection";
 import TemplateGallery from "../sections/TemplatesSection";
+import OnboardingChat from "../onboarding/OnboardingChat";
+import { isIntentPrompted, markIntentPrompted } from "../../lib/onboarding/intentPromptFlag";
 // KeywordsSection removed from MVP navigation - functionality merged into Optimize section
 
 // Lazy-loaded tab sections — each gets its own chunk
@@ -289,6 +291,15 @@ export default function MainContent() {
 
   const [activeTab, setActiveTab] = useState("resume");
   const [flowProgress, setFlowProgress] = useState(0);
+  // Path-A intent capture: after a successful parse, auto-show the inline role/comp/
+  // location prompt unless intent already exists or the user resolved the prompt.
+  const searchIntent = useResumeStore((state) => state.searchIntent);
+  const hasParsedResume = useResumeStore((state) => Boolean(state.originalResume));
+  const [intentPrompted, setIntentPrompted] = useState(isIntentPrompted);
+  const resolveIntentPrompt = useCallback(() => {
+    markIntentPrompted();
+    setIntentPrompted(true);
+  }, []);
   const [resumeData, setResumeData] = useState(() => {
     if (typeof window === "undefined") return "";
     try {
@@ -1848,12 +1859,27 @@ export default function MainContent() {
           {/* Parse-quality warning — shown on all tabs so the user always sees it */}
           {activeTab !== "resume" && <ParsingWarningsBanner />}
           {activeTab === "resume" && (
-            <UploadSection
-              onParseResume={handleParseResume}
-              resumeDocument={resumeData}
-              onToast={handleUploadToast}
-              onClear={handleClearResume}
-            />
+            <>
+              <UploadSection
+                onParseResume={handleParseResume}
+                resumeDocument={resumeData}
+                onToast={handleUploadToast}
+                onClear={handleClearResume}
+              />
+              {/* Path-A inline intent capture — auto-shows after a successful parse,
+                  skippable, never blocks upload. Hidden once intent exists or the
+                  user resolves the prompt. */}
+              {hasParsedResume && !searchIntent && !intentPrompted && (
+                <div className="mt-4">
+                  <OnboardingChat
+                    path="has_cv"
+                    mode="inline"
+                    onComplete={resolveIntentPrompt}
+                    onDismiss={resolveIntentPrompt}
+                  />
+                </div>
+              )}
+            </>
           )}
           {activeTab === "match" && (
             <LazyErrorBoundary label="Match section">

--- a/src/components/Layout/MainContent.tsx
+++ b/src/components/Layout/MainContent.tsx
@@ -292,10 +292,17 @@ export default function MainContent() {
   const [activeTab, setActiveTab] = useState("resume");
   const [flowProgress, setFlowProgress] = useState(0);
   // Path-A intent capture: after a successful parse, auto-show the inline role/comp/
-  // location prompt unless intent already exists or the user resolved the prompt.
-  const searchIntent = useResumeStore((state) => state.searchIntent);
+  // location prompt. The mount gate must NOT depend on searchIntent being empty —
+  // OnboardingChat writes searchIntent at the very first (role) slot, so gating on
+  // emptiness would unmount the panel mid-flow before comp/location. Gate on
+  // resume-parsed AND !intentPrompted; the child owns slot progression and the parent
+  // only unmounts when it fires onComplete/onDismiss (which sets intentPrompted).
+  // Seed intentPrompted true when an intent already exists so returning users with a
+  // saved intent are not re-prompted — read once at mount, never reactively.
   const hasParsedResume = useResumeStore((state) => Boolean(state.originalResume));
-  const [intentPrompted, setIntentPrompted] = useState(isIntentPrompted);
+  const [intentPrompted, setIntentPrompted] = useState(
+    () => isIntentPrompted() || Boolean(useResumeStore.getState().searchIntent),
+  );
   const resolveIntentPrompt = useCallback(() => {
     markIntentPrompted();
     setIntentPrompted(true);
@@ -1867,9 +1874,9 @@ export default function MainContent() {
                 onClear={handleClearResume}
               />
               {/* Path-A inline intent capture — auto-shows after a successful parse,
-                  skippable, never blocks upload. Hidden once intent exists or the
-                  user resolves the prompt. */}
-              {hasParsedResume && !searchIntent && !intentPrompted && (
+                  skippable, never blocks upload. Stays mounted across role -> comp ->
+                  location; only unmounts when the child resolves the prompt. */}
+              {hasParsedResume && !intentPrompted && (
                 <div className="mt-4">
                   <OnboardingChat
                     path="has_cv"

--- a/src/components/onboarding/OnboardingChat.tsx
+++ b/src/components/onboarding/OnboardingChat.tsx
@@ -13,8 +13,16 @@ import { useResumeStore } from '@/lib/stores/resumeStore';
 interface OnboardingChatProps {
   /** has_cv when a resume was already parsed; no_cv to build a starter CV from answers. */
   path?: OnboardingPath;
+  /**
+   * 'fullscreen' (default) = first-run gate screen, starts at cv_basics.
+   * 'inline' = compact post-upload panel; cv_basics is already known from parse, so it
+   * starts at the role slot and renders nothing once done (parent unmounts it).
+   */
+  mode?: 'fullscreen' | 'inline';
   /** Called once the machine reaches done. */
   onComplete?: () => void;
+  /** Inline only: user dismissed the whole panel ("Not now"). */
+  onDismiss?: () => void;
 }
 
 interface SlotCopy {
@@ -51,7 +59,8 @@ function emptyIntent(confidence: SlotConfidence): SearchIntent {
   return { targetRoles: [], meta: { confidence, completeness: 0, updatedAt: new Date().toISOString() } };
 }
 
-export default function OnboardingChat({ path: pathProp, onComplete }: OnboardingChatProps) {
+export default function OnboardingChat({ path: pathProp, mode = 'fullscreen', onComplete, onDismiss }: OnboardingChatProps) {
+  const inline = mode === 'inline';
   const originalResume = useResumeStore((s) => s.originalResume);
   const storedIntent = useResumeStore((s) => s.searchIntent);
   const setSearchIntent = useResumeStore((s) => s.setSearchIntent);
@@ -62,7 +71,11 @@ export default function OnboardingChat({ path: pathProp, onComplete }: Onboardin
   const path: OnboardingPath = pathProp ?? (originalResume?.basics?.name ? 'has_cv' : 'no_cv');
   const baseConfidence: SlotConfidence = path === 'no_cv' ? 'low' : 'medium';
 
-  const [machine, setMachine] = useState(() => initialState(path));
+  // Inline (Path A) skips cv_basics — name/title already came from parse-resume — so
+  // pre-mark it answered and start at role.
+  const [machine, setMachine] = useState(() =>
+    inline ? advance(initialState(path), 'cv_basics') : initialState(path),
+  );
   const [text, setText] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -194,6 +207,8 @@ export default function OnboardingChat({ path: pathProp, onComplete }: Onboardin
   }, [current, goNext]);
 
   if (current === 'done') {
+    // Inline: nothing to show — the parent unmounts the panel on complete.
+    if (inline) return null;
     const completeness = getProfileCompleteness();
     return (
       <div className="mx-auto flex max-w-md flex-col items-center gap-4 p-6 text-center">
@@ -224,7 +239,30 @@ export default function OnboardingChat({ path: pathProp, onComplete }: Onboardin
   }
 
   return (
-    <div className="mx-auto flex max-w-md flex-col gap-5 p-6">
+    <div
+      className={
+        inline
+          ? 'flex flex-col gap-4 rounded-xl border border-emerald-500/30 bg-slate-800/40 p-4'
+          : 'mx-auto flex max-w-md flex-col gap-5 p-6'
+      }
+    >
+      {/* Inline header: a one-line "why" + a dismiss affordance. */}
+      {inline && (
+        <div className="flex items-start justify-between gap-3">
+          <p className="text-sm font-medium text-emerald-300">
+            Tailor results to your goal — takes 20 seconds.
+          </p>
+          <button
+            type="button"
+            onClick={() => onDismiss?.()}
+            disabled={busy}
+            className="shrink-0 text-sm text-slate-400 underline-offset-2 hover:underline disabled:opacity-50"
+          >
+            Not now
+          </button>
+        </div>
+      )}
+
       {/* Progress dots */}
       <div className="flex items-center justify-center gap-2" aria-label={`Step ${answered + 1} of ${total}`}>
         {Array.from({ length: total }).map((_, i) => (
@@ -235,8 +273,8 @@ export default function OnboardingChat({ path: pathProp, onComplete }: Onboardin
         ))}
       </div>
 
-      <div className="text-center">
-        <h2 className="text-xl font-bold text-slate-100">{copy?.title}</h2>
+      <div className={inline ? 'text-start' : 'text-center'}>
+        <h2 className={inline ? 'text-lg font-bold text-slate-100' : 'text-xl font-bold text-slate-100'}>{copy?.title}</h2>
         <p className="mt-1 text-sm text-slate-400">{copy?.hint}</p>
       </div>
 

--- a/src/components/onboarding/OnboardingChat.tsx
+++ b/src/components/onboarding/OnboardingChat.tsx
@@ -3,7 +3,7 @@
 // common answers, a Skip on every slot, progress dots, plain text input (the OS
 // keyboard mic supplies voice). Each answer calls onboard-extract, patches the store
 // through the single writer, and advances the pure state machine.
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { OnboardingPath, OnboardingSlot, SearchIntent, SlotConfidence } from '@/types/onboarding';
 import type { Basics } from '@/types/resume';
 import { advance, initialState, progress, terminalAction } from '@/lib/onboarding/flow';
@@ -79,8 +79,11 @@ export default function OnboardingChat({ path: pathProp, mode = 'fullscreen', on
   const [text, setText] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Local working copy of the intent; mirrored into the store on every change.
-  const [intent, setIntent] = useState<SearchIntent>(() => storedIntent ?? emptyIntent(baseConfidence));
+  // Working copy of the intent, held in a ref (not state) so committing it writes to
+  // the store synchronously in the event handler. Doing the store write inside a
+  // setState updater silently dropped the final slot: on the last answer the panel
+  // unmounts in the same tick, so the updater's side effect never flushed.
+  const intentRef = useRef<SearchIntent>(storedIntent ?? emptyIntent(baseConfidence));
 
   const current = machine.current;
   const copy = current !== 'done' ? SLOT_COPY[path][current] : null;
@@ -103,11 +106,10 @@ export default function OnboardingChat({ path: pathProp, mode = 'fullscreen', on
 
   const commitIntent = useCallback(
     (partial: Partial<SearchIntent>) => {
-      setIntent((prev) => {
-        const next: SearchIntent = { ...prev, ...partial, meta: { ...prev.meta, confidence: baseConfidence } };
-        setSearchIntent(next);
-        return next;
-      });
+      const prev = intentRef.current;
+      const next: SearchIntent = { ...prev, ...partial, meta: { ...prev.meta, confidence: baseConfidence } };
+      intentRef.current = next;
+      setSearchIntent(next);
     },
     [baseConfidence, setSearchIntent],
   );
@@ -171,7 +173,7 @@ export default function OnboardingChat({ path: pathProp, mode = 'fullscreen', on
     setBusy(true);
     setError(null);
     try {
-      const { value } = await onboardExtract({ slot: current, userText, currentIntent: intent });
+      const { value } = await onboardExtract({ slot: current, userText, currentIntent: intentRef.current });
       applySlotValue(current, value);
       goNext(current);
     } catch (err) {
@@ -180,16 +182,16 @@ export default function OnboardingChat({ path: pathProp, mode = 'fullscreen', on
     } finally {
       setBusy(false);
     }
-  }, [applySlotValue, current, goNext, intent, prefill, text]);
+  }, [applySlotValue, current, goNext, prefill, text]);
 
   // Chips set structured values directly — no AI round-trip needed.
   const pickWorkMode = useCallback(
     (workMode: 'remote' | 'hybrid' | 'onsite') => {
       if (current !== 'location') return;
-      commitIntent({ location: { ...(intent.location ?? {}), workMode } });
+      commitIntent({ location: { ...(intentRef.current.location ?? {}), workMode } });
       goNext('location');
     },
-    [commitIntent, current, goNext, intent.location],
+    [commitIntent, current, goNext],
   );
 
   const pickCompBand = useCallback(

--- a/src/components/onboarding/__tests__/OnboardingChat.inline.test.tsx
+++ b/src/components/onboarding/__tests__/OnboardingChat.inline.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OnboardingChat from '../OnboardingChat';
+import { useResumeStore } from '@/lib/stores/resumeStore';
+
+vi.mock('@/services/api', () => ({
+  onboardExtract: vi.fn(),
+}));
+
+describe('OnboardingChat — inline (Path A) mode', () => {
+  beforeEach(() => {
+    useResumeStore.setState({ originalResume: null, searchIntent: null });
+  });
+
+  it('starts at the role slot, skipping cv_basics', () => {
+    render(<OnboardingChat path="has_cv" mode="inline" />);
+
+    expect(screen.getByText('What role are you targeting?')).toBeInTheDocument();
+    // cv_basics confirm step must NOT appear inline — name/title came from parse.
+    expect(screen.queryByText('Is this you?')).toBeNull();
+  });
+
+  it('renders a "Not now" dismiss that calls onDismiss', () => {
+    const onDismiss = vi.fn();
+    render(<OnboardingChat path="has_cv" mode="inline" onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /not now/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('advances role -> comp -> location with Skip without any AI call', () => {
+    render(<OnboardingChat path="has_cv" mode="inline" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+    expect(screen.getByText('What salary are you after?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+    expect(screen.getByText('Where do you want to work?')).toBeInTheDocument();
+  });
+
+  it('calls onComplete after the final slot (location) is resolved', () => {
+    const onComplete = vi.fn();
+    render(<OnboardingChat path="has_cv" mode="inline" onComplete={onComplete} />);
+
+    // role -> comp -> location -> done
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, createContext, useContext } from "react";
 import { resolveAuthRedirectUrl } from "../lib/auth/authRedirect";
 import { useResumeStore } from "@/lib/stores/resumeStore";
+import { flushSearchIntentOnSignIn } from "@/lib/onboarding/flushSearchIntent";
 import { analytics } from "../services/analytics";
 import { supabase } from "../services/supabase";
 import type { User } from "@supabase/supabase-js";
@@ -185,6 +186,8 @@ export const AuthProvider = ({ children }) => {
       // Track referral for new signups
       if (currentUser && !previousUserId && _event === "SIGNED_IN") {
         trackReferralAfterSignup(currentUser.id, session?.access_token);
+        // Flush any guest-collected searchIntent to the server (idempotent).
+        flushSearchIntentOnSignIn(session?.access_token);
       }
 
       lastUserIdRef.current = currentUserId;

--- a/src/lib/onboarding/__tests__/flushSearchIntent.test.ts
+++ b/src/lib/onboarding/__tests__/flushSearchIntent.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSearchIntentOnSignIn } from '../flushSearchIntent';
+import { useResumeStore } from '@/lib/stores/resumeStore';
+import type { SearchIntent } from '@/types/onboarding';
+
+const intent: SearchIntent = {
+  targetRoles: ['Frontend Engineer'],
+  meta: { confidence: 'medium', completeness: 50, updatedAt: '2026-01-01T00:00:00.000Z' },
+};
+
+const jsonResponse = (body: unknown, ok = true) => ({ ok, json: async () => body });
+
+describe('flushSearchIntentOnSignIn', () => {
+  beforeEach(() => {
+    useResumeStore.setState({ searchIntent: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does nothing when there is no local intent', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await flushSearchIntentOnSignIn('token');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without an access token', async () => {
+    useResumeStore.setState({ searchIntent: intent });
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await flushSearchIntentOnSignIn(undefined);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: skips the save when the server already has an intent', async () => {
+    useResumeStore.setState({ searchIntent: intent });
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ searchIntent: intent }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await flushSearchIntentOnSignIn('token');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // only the GET
+    const getBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(getBody.action).toBe('get_search_intent');
+  });
+
+  it('saves the local intent when the server has none', async () => {
+    useResumeStore.setState({ searchIntent: intent });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ searchIntent: null })) // GET
+      .mockResolvedValueOnce(jsonResponse({ success: true })); // SAVE
+    vi.stubGlobal('fetch', fetchMock);
+
+    await flushSearchIntentOnSignIn('token');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const saveCall = fetchMock.mock.calls[1][1];
+    const saveBody = JSON.parse(saveCall.body);
+    expect(saveBody.action).toBe('save_search_intent');
+    expect(saveBody.searchIntent).toEqual(intent);
+    expect(saveCall.headers.Authorization).toBe('Bearer token');
+  });
+});

--- a/src/lib/onboarding/flushSearchIntent.ts
+++ b/src/lib/onboarding/flushSearchIntent.ts
@@ -1,0 +1,48 @@
+// src/lib/onboarding/flushSearchIntent.ts
+// Guest -> sign-in flush. A guest can complete onboarding before signing in, so the
+// searchIntent lives only in the local store (persisted under `resume-storage`). On
+// the first sign-in, push it to the server — idempotently: if the server row already
+// has an intent, leave it (server wins). Called from useAuth on SIGNED_IN.
+import { useResumeStore } from '@/lib/stores/resumeStore';
+
+const USER_DATA_API = '/.netlify/functions/user-data-api';
+
+export async function flushSearchIntentOnSignIn(accessToken?: string): Promise<void> {
+  const localIntent = useResumeStore.getState().searchIntent;
+  if (!localIntent) return; // nothing collected as a guest
+
+  if (!accessToken) {
+    console.warn('[useAuth] Cannot flush searchIntent without an auth token');
+    return;
+  }
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${accessToken}`,
+  };
+
+  try {
+    // Idempotent: if the server already has an intent, do not overwrite it.
+    const existing = await fetch(USER_DATA_API, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ action: 'get_search_intent' }),
+    });
+    if (existing.ok) {
+      const data = await existing.json().catch(() => ({}));
+      if (data?.searchIntent) return; // server already has intent — skip
+    }
+
+    const saved = await fetch(USER_DATA_API, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ action: 'save_search_intent', searchIntent: localIntent }),
+    });
+    if (!saved.ok) {
+      const err = await saved.json().catch(() => ({}));
+      console.error('[useAuth] Failed to flush searchIntent:', err);
+    }
+  } catch (error) {
+    console.error('[useAuth] Error flushing searchIntent:', error);
+  }
+}

--- a/src/lib/onboarding/intentPromptFlag.ts
+++ b/src/lib/onboarding/intentPromptFlag.ts
@@ -1,0 +1,23 @@
+// src/lib/onboarding/intentPromptFlag.ts
+// "User has resolved the post-upload intent prompt" flag (completed OR dismissed).
+// Stops the inline Path-A panel from re-appearing on every render when the user
+// skipped every slot and searchIntent is still empty. Storage key uses watheq: prefix.
+const INTENT_PROMPTED_KEY = 'watheq:intentPrompted';
+
+export function isIntentPrompted(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(INTENT_PROMPTED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function markIntentPrompted(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(INTENT_PROMPTED_KEY, 'true');
+  } catch {
+    // Private mode / storage disabled — panel falls back to searchIntent presence.
+  }
+}


### PR DESCRIPTION
Stacked on #114, sibling to #115. Closes the gap called out in #115: upload-first (Path A) users now get role/comp/location captured, so `searchIntent` is populated and the optimize injection works for them too.

## What
After a successful upload/parse-resume, an **inline, auto-shown, skippable** panel appears in the resume tab (not a full-screen gate, never blocks upload).

- `OnboardingChat` gains `mode="inline"`: compact card, **starts at the role slot** (name/title already came from parse), renders nothing once done; plus an `onDismiss` ("Not now")
- `intentPromptFlag` (`watheq:intentPrompted`) set on complete **or** dismiss → no re-nag when the user skipped every slot and intent is still empty
- Wired in `MainContent` resume tab after `<UploadSection/>`, shown when: resume parsed + no `searchIntent` + prompt unresolved
- Per-slot Skip + whole-panel "Not now" both supported

## Wire point
`src/components/Layout/MainContent.tsx`, `activeTab === "resume"` block, directly after `<UploadSection/>`. `handleParseResume` does not change tabs, so the user stays on the resume tab and sees the panel; upload completes and populates the store first.

## Verification
`npm run quality:parallel`: lint + types clean; 960 tests, only a known parallel-load flake (`MainContent.test.jsx` clarifications test) which **passes in isolation** (whole file 21/21). New inline tests: 4/4.

## After this lands
Item 1 (#114) is complete and can ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
