### PR TITLE
chore(onboarding): trim scope — drop salary slot + optimize injection

### DIFF
--- a/docs/onboarding-v1.md
+++ b/docs/onboarding-v1.md
@@ -2,22 +2,28 @@
 
 Implemented spec. A first-time phone user finishes onboarding without a form and
 without uploading twice. Output is the canonical profile: existing resume data plus
-a new `searchIntent` (target role, comp, location). Every later job tailoring reads
-from it.
+a new `searchIntent` (target role, location). Role feeds the no-CV starter-CV path
+and is kept as profile-level signal for future personalization (item 2).
+
+**Scope note:** salary/comp was dropped entirely — it fed nothing downstream (no
+display, no tailoring signal), just a sensitive question with no payoff. `role` and
+`location` are collected but are NOT injected into the optimize prompt: `optimize`
+always requires a job description, which already dominates tailoring, so there is no
+"no-JD" case that would justify biasing the AI call with stated intent.
 
 ## Design
 
 - **No parallel store.** Canonical profile is `resumeStore` + the Supabase resume row.
   Onboarding only populates it. `searchIntent` is the one new slice.
-- **Deterministic slot-filling, not a free agent.** Slots: `cv_basics`, `role`, `comp`,
+- **Deterministic slot-filling, not a free agent.** Slots: `cv_basics`, `role`,
   `location`. Fixed client-side sequence (`src/lib/onboarding/flow.ts`). The LLM is
   called once per answer (`onboard-extract`), only to parse one freeform reply into
   one structured slot value. No server-side multi-turn loop.
 - **Voice = the OS keyboard mic.** Plain text input; the native keyboard dictation
   button gives voice on iOS/Android. No STT code.
 - **Two paths, one destination.**
-  - Path A (has CV): upload/paste → `parse-resume` → confirm name/title → role → comp → location → done.
-  - Path B (no CV): name → role → 1-2 achievements → comp → location → generate starter CV → done.
+  - Path A (has CV): upload/paste → `parse-resume` → confirm name/title → role → location → done.
+  - Path B (no CV): name → role → 1-2 achievements → location → generate starter CV → done.
 - **Onboard guests, gate save behind sign-in.** Guests complete onboarding in-store;
   flush to Supabase on sign-in.
 
@@ -33,7 +39,6 @@ from it.
 | Store slice | `resumeStore.ts` (`searchIntent`, `setSearchIntent`, `patchProfile`, `getProfileCompleteness`) |
 | UI | `src/components/onboarding/OnboardingChat.tsx` |
 | Persistence | `user-data-api` actions `save_search_intent` / `get_search_intent` |
-| Per-job effect | `optimize` / `optimize-stream` inject `target_search_intent` into the prompt |
 | Migration | `supabase/migrations/20260630000000_add_search_intent.sql` (run manually) |
 
 ## Storage keys

--- a/netlify/functions/__tests__/optimize-stream.test.ts
+++ b/netlify/functions/__tests__/optimize-stream.test.ts
@@ -245,7 +245,7 @@ describe('optimize-stream function', () => {
       [],
       undefined,
       undefined,
-      { featureName: 'optimize_stream', searchIntent: null }
+      { featureName: 'optimize_stream' }
     );
     const options = mockGeminiClient.optimizeResume.mock.calls[0][6];
     expect(options).not.toHaveProperty('resumeText');
@@ -280,7 +280,7 @@ describe('optimize-stream function', () => {
       [],
       undefined,
       ['Excel'],
-      { featureName: 'optimize_stream', searchIntent: null },
+      { featureName: 'optimize_stream' },
     );
   });
 

--- a/netlify/functions/__tests__/optimize.test.ts
+++ b/netlify/functions/__tests__/optimize.test.ts
@@ -181,7 +181,6 @@ describe('optimize function', () => {
             [],
             undefined,
             ['Excel'],
-            { searchIntent: null },
         );
     });
 

--- a/netlify/functions/onboard-extract.ts
+++ b/netlify/functions/onboard-extract.ts
@@ -55,23 +55,6 @@ const SLOT_SCHEMAS: Record<string, object> = {
     },
     required: ['value', 'confidence'],
   },
-  comp: {
-    type: 'object',
-    properties: {
-      value: {
-        type: 'object',
-        properties: {
-          min: { type: 'number' },
-          max: { type: 'number' },
-          currency: { type: 'string' },
-          period: { type: 'string', enum: ['', 'month', 'year'] },
-        },
-        required: ['min', 'max', 'currency', 'period'],
-      },
-      confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
-    },
-    required: ['value', 'confidence'],
-  },
   location: {
     type: 'object',
     properties: {
@@ -95,8 +78,6 @@ const SLOT_INSTRUCTIONS: Record<string, string> = {
     'Extract the person\'s full name into "name", their current/target job title into "label", and up to two concrete things they have done into "achievements" (each a short phrase). Leave a field as an empty string / empty array if the answer does not contain it. Do not invent details.',
   role:
     'Extract the target job role(s) the person wants into "targetRoles" (usually one, at most a few). Infer "seniority" only if the role text clearly states it (e.g. "senior", "lead", "manager"); otherwise return an empty string. Do not invent a seniority.',
-  comp:
-    'Extract the desired salary into "min" and "max" as plain numbers (no separators). If a single figure is given, set both min and max to it. Extract "currency" as a 3-letter-ish code (default "SAR" if a bare number is given in a Saudi context). Set "period" to "month" or "year" based on the text, or empty string if unclear. Use 0 for an unknown bound.',
   location:
     'Extract the preferred work "city" and "country" (use the country code like "SA" when obvious). Set "workMode" to remote, hybrid, or onsite if stated, else empty string. Leave city/country empty if not stated.',
 };
@@ -132,24 +113,6 @@ function normalizeSlotValue(slot: string, raw: unknown): Record<string, unknown>
       out.seniority = v.seniority;
     }
     return out;
-  }
-
-  if (slot === 'comp') {
-    const min = typeof v.min === 'number' ? v.min : 0;
-    const max = typeof v.max === 'number' ? v.max : 0;
-    const period = v.period === 'month' || v.period === 'year' ? v.period : null;
-    // Only return a compRange if we got something usable.
-    if ((min > 0 || max > 0) && period) {
-      return {
-        compRange: {
-          min: min || max,
-          max: max || min,
-          currency: typeof v.currency === 'string' && v.currency.trim() ? v.currency.trim() : 'SAR',
-          period,
-        },
-      };
-    }
-    return {};
   }
 
   if (slot === 'location') {

--- a/netlify/functions/optimize-stream.ts
+++ b/netlify/functions/optimize-stream.ts
@@ -158,7 +158,7 @@ export default async function handler(request: Request): Promise<Response> {
     );
   }
 
-  const { resumeText, jobText, workHistory, language, userClarifications, userHardStops, cacheOnly, searchIntent } = parseResult.data;
+  const { resumeText, jobText, workHistory, language, userClarifications, userHardStops, cacheOnly } = parseResult.data;
 
   // --- Vulnerability detection (needed for both cache key and AI call) ---
   const vulnerabilities = workHistory?.length
@@ -191,7 +191,6 @@ export default async function handler(request: Request): Promise<Response> {
     vulnerabilities: vulnerabilities.map((v: any) => v.type).sort(),
     userClarifications: userClarifications || '',
     userHardStops: userHardStops || [],
-    searchIntent: searchIntent || null,
   });
 
   const cachedResponse = await getCached<Record<string, unknown>>(cacheKey);
@@ -272,7 +271,6 @@ export default async function handler(request: Request): Promise<Response> {
 
         const optimization = await optimizeResume(resumeText, jobText, language, vulnerabilities, userClarifications, userHardStops, {
           featureName: "optimize_stream",
-          searchIntent: searchIntent || null,
         });
 
         const aiDuration = Date.now() - startTime;

--- a/netlify/functions/optimize.ts
+++ b/netlify/functions/optimize.ts
@@ -123,7 +123,7 @@ const baseHandler: Handler = async (event) => {
       };
     }
 
-    const { resumeText, jobText, workHistory, language, userClarifications, userHardStops, searchIntent } = parseResult.data;
+    const { resumeText, jobText, workHistory, language, userClarifications, userHardStops } = parseResult.data;
 
     // Detect career vulnerabilities from structured work history
     const vulnerabilities = workHistory?.length
@@ -144,7 +144,6 @@ const baseHandler: Handler = async (event) => {
       vulnerabilities: vulnerabilities.map((v: any) => v.type).sort(),
       userClarifications: userClarifications || '',
       userHardStops: userHardStops || [],
-      searchIntent: searchIntent || null,
     });
 
     const cachedResponse = await getCached<Record<string, unknown>>(cacheKey);
@@ -173,7 +172,6 @@ const baseHandler: Handler = async (event) => {
       vulnerabilities,
       userClarifications,
       userHardStops,
-      { searchIntent: searchIntent || null },
     );
 
     console.log(`[optimize] Gemini call took ${Date.now() - startTime}ms`);

--- a/netlify/lib/ai-contracts/contracts/index.js
+++ b/netlify/lib/ai-contracts/contracts/index.js
@@ -896,25 +896,7 @@ function buildOptimizeMessages(input, context) {
     ? `\nThe user explicitly confirmed NO experience with the items in user_hard_stops. Do NOT add, imply, infer, or weave any of them into bullets, summary, headline, or skills. Remove them from missing_keywords suggestions. This overrides any keyword-weaving rule.`
     : '';
 
-  // Onboarding job-search intent: bias tailoring toward the target role / level /
-  // location WITHOUT inventing experience. Does not alter the strict scoring rubric.
-  const searchIntent = input.searchIntent && typeof input.searchIntent === 'object' ? input.searchIntent : null;
-  const intentLines = [];
-  if (searchIntent) {
-    const roles = Array.isArray(searchIntent.targetRoles) ? searchIntent.targetRoles.filter(Boolean) : [];
-    if (roles.length) intentLines.push(`Target role(s): ${roles.join(', ')}`);
-    if (searchIntent.seniority) intentLines.push(`Target seniority: ${searchIntent.seniority}`);
-    const loc = searchIntent.location;
-    if (loc && (loc.city || loc.country || loc.workMode)) {
-      intentLines.push(`Preferred location: ${[loc.city, loc.country, loc.workMode].filter(Boolean).join(', ')}`);
-    }
-  }
-  const searchIntentBlock = intentLines.length ? optionalTaggedBlock('target_search_intent', intentLines.join('\n')) : '';
-  const searchIntentInstruction = intentLines.length
-    ? `\nThe user is targeting the role in target_search_intent. Frame the headline, summary, and bullet emphasis toward that role and seniority, surfacing the most relevant real experience first. Do NOT invent experience, titles, or skills the resume does not support, and do NOT change the strict scoring rubric.`
-    : '';
-
-  const system = `${OPTIMIZE_TRUTHFULNESS_SYSTEM}${hardStopInstruction}${searchIntentInstruction}`;
+  const system = `${OPTIMIZE_TRUTHFULNESS_SYSTEM}${hardStopInstruction}`;
   const example = `Example item:
 - original: "Responsible for improving the API and making it faster for users."
 - improved: "Cut customer-facing API latency 40% by adding Redis caching and rewriting N+1 queries."
@@ -925,7 +907,6 @@ function buildOptimizeMessages(input, context) {
 
 ${example}${languageInstruction}${withRagBlock(context.retrievedContext)}${vulnerabilityBlock}${clarificationsBlock}
 ${hardStopsBlock}
-${searchIntentBlock}
 
 ${taggedBlock('job_description', jobDescription)}
 

--- a/netlify/lib/gemini-client.js
+++ b/netlify/lib/gemini-client.js
@@ -143,7 +143,6 @@ export async function optimizeResume(resumeText, jobDescription, language = 'en'
       vulnerabilities,
       userClarifications,
       userHardStops,
-      searchIntent: options.searchIntent || null,
     }, {
       ...options,
       featureName: options.featureName || 'optimize_resume',

--- a/netlify/lib/resume-schemas.ts
+++ b/netlify/lib/resume-schemas.ts
@@ -179,12 +179,6 @@ export const ResumeSchema = z.object({
 export const SearchIntentSchema = z.object({
     targetRoles: z.array(z.string().trim().min(1).max(200)).max(10).default([]),
     seniority: z.enum(['junior', 'mid', 'senior', 'lead', 'manager']).optional(),
-    compRange: z.object({
-        min: z.number().nonnegative(),
-        max: z.number().nonnegative(),
-        currency: z.string().trim().min(1).max(8),
-        period: z.enum(['month', 'year']),
-    }).optional(),
     location: z.object({
         city: z.string().trim().max(120).optional(),
         country: z.string().trim().max(120).optional(),
@@ -250,9 +244,6 @@ export const OptimizeRequestSchema = z.object({
     userHardStops: z.array(z.string().trim().min(1).max(300)).max(20).optional(),
     // Recovery-only retry after an interrupted paid stream. Must never trigger AI or credit use.
     cacheOnly: z.boolean().optional(),
-    // Job-search intent from onboarding. Injected into the tailoring prompt so the
-    // stored profile changes per-job output (target role / comp / location).
-    searchIntent: SearchIntentSchema.optional(),
     freePreview: z.boolean().optional(),
 });
 
@@ -282,7 +273,7 @@ export const CoverLetterRequestSchema = z.object({
 
 // Onboarding slot extraction: one freeform reply → one structured slot value.
 export const OnboardExtractRequestSchema = z.object({
-    slot: z.enum(['cv_basics', 'role', 'comp', 'location']),
+    slot: z.enum(['cv_basics', 'role', 'location']),
     userText: z.string().min(1, "Answer text is required").max(2000, "Answer too long"),
     currentIntent: SearchIntentSchema.optional(),
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,8 +41,8 @@ export default function App() {
       const resumeState = useResumeStore.getState();
       return (
         !isOnboarded() &&
-        !Boolean(resumeState.originalResume || resumeState.parsedResumeText) &&
-        !Boolean(resumeState.searchIntent)
+        !(resumeState.originalResume || resumeState.parsedResumeText) &&
+        !resumeState.searchIntent
       );
     }
   );

--- a/src/__tests__/MainContent.test.jsx
+++ b/src/__tests__/MainContent.test.jsx
@@ -728,7 +728,7 @@ describe("MainContent resume parsing", () => {
     expect(screen.getAllByText(/Pipeline/i).length).toBeGreaterThan(0);
   });
 
-  it("keeps the Path-A intent panel mounted across role -> comp -> location, then unmounts on complete", async () => {
+  it("keeps the Path-A intent panel mounted across role -> location, then unmounts on complete", async () => {
     // Signed-in user, freshly parsed resume in the store, no intent yet, prompt unseen.
     localStorage.setItem("watheq:lastActiveTab", "resume");
     localStorage.setItem("watheq:resumeData", JSON.stringify({ plainText: "Parsed resume", basics: { name: "Sara Al-Otaibi" }, sections: [] }));
@@ -754,13 +754,9 @@ describe("MainContent resume parsing", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /^next$/i }));
 
-    // comp slot appears -> panel stayed mounted even though intent is now non-empty.
-    expect(await screen.findByText("What salary are you after?")).toBeInTheDocument();
-    expect(useResumeStore.getState().searchIntent?.targetRoles).toEqual(["Frontend Engineer"]);
-
-    // comp via chip -> location
-    fireEvent.click(screen.getByRole("button", { name: /10.15k SAR\/mo/i }));
+    // location slot appears -> panel stayed mounted even though intent is now non-empty.
     expect(await screen.findByText("Where do you want to work?")).toBeInTheDocument();
+    expect(useResumeStore.getState().searchIntent?.targetRoles).toEqual(["Frontend Engineer"]);
 
     // location via chip -> final slot resolved -> onComplete -> panel unmounts
     fireEvent.click(screen.getByRole("button", { name: /^remote$/i }));
@@ -770,7 +766,6 @@ describe("MainContent resume parsing", () => {
     });
     expect(localStorage.getItem("watheq:intentPrompted")).toBe("true");
     const intent = useResumeStore.getState().searchIntent;
-    expect(intent?.compRange).toBeTruthy();
     expect(intent?.location?.workMode).toBe("remote");
   });
 });

--- a/src/components/Layout/MainContent.tsx
+++ b/src/components/Layout/MainContent.tsx
@@ -1183,7 +1183,6 @@ export default function MainContent() {
               workHistory,
               userClarifications,
               userHardStops,
-              searchIntent: useResumeStore.getState().searchIntent,
               freePreview,
             },
             // onStatus callback: update toast with real-time progress
@@ -1223,7 +1222,6 @@ export default function MainContent() {
               workHistory,
               userClarifications,
               userHardStops,
-              searchIntent: useResumeStore.getState().searchIntent,
               freePreview,
             }
           );

--- a/src/components/onboarding/OnboardingChat.tsx
+++ b/src/components/onboarding/OnboardingChat.tsx
@@ -35,25 +35,16 @@ const SLOT_COPY: Record<OnboardingPath, Record<OnboardingSlot, SlotCopy>> = {
   has_cv: {
     cv_basics: { title: 'Is this you?', hint: 'Confirm or fix your name and title.', placeholder: 'Name — Job title' },
     role: { title: 'What role are you targeting?', hint: 'One target is enough.', placeholder: 'e.g. Senior Frontend Engineer' },
-    comp: { title: 'What salary are you after?', hint: 'A range is fine. Tap a band or type it.', placeholder: 'e.g. 15,000 SAR / month' },
     location: { title: 'Where do you want to work?', hint: 'City and how you want to work.', placeholder: 'e.g. Riyadh, hybrid' },
   },
   no_cv: {
     cv_basics: { title: "Let's start with you", hint: 'Your name and one or two things you have done.', placeholder: 'e.g. Sara Al-Otaibi — built a payments dashboard, led a 3-person team' },
     role: { title: 'What role are you targeting?', hint: 'One target is enough.', placeholder: 'e.g. Product Designer' },
-    comp: { title: 'What salary are you after?', hint: 'A range is fine. Tap a band or type it.', placeholder: 'e.g. 15,000 SAR / month' },
     location: { title: 'Where do you want to work?', hint: 'City and how you want to work.', placeholder: 'e.g. Jeddah, onsite' },
   },
 };
 
 const WORK_MODES: Array<'remote' | 'hybrid' | 'onsite'> = ['remote', 'hybrid', 'onsite'];
-const COMP_BANDS = [
-  { label: '5–10k', min: 5000, max: 10000 },
-  { label: '10–15k', min: 10000, max: 15000 },
-  { label: '15–20k', min: 15000, max: 20000 },
-  { label: '20–30k', min: 20000, max: 30000 },
-  { label: '30k+', min: 30000, max: 45000 },
-];
 
 function emptyIntent(confidence: SlotConfidence): SearchIntent {
   return { targetRoles: [], meta: { confidence, completeness: 0, updatedAt: new Date().toISOString() } };
@@ -154,10 +145,6 @@ export default function OnboardingChat({ path: pathProp, mode = 'fullscreen', on
         commitIntent({ targetRoles: roles, ...(seniority ? { seniority } : {}) });
         return;
       }
-      if (slot === 'comp' && value.compRange) {
-        commitIntent({ compRange: value.compRange as SearchIntent['compRange'] });
-        return;
-      }
       if (slot === 'location' && value.location) {
         commitIntent({ location: value.location as SearchIntent['location'] });
       }
@@ -190,15 +177,6 @@ export default function OnboardingChat({ path: pathProp, mode = 'fullscreen', on
       if (current !== 'location') return;
       commitIntent({ location: { ...(intentRef.current.location ?? {}), workMode } });
       goNext('location');
-    },
-    [commitIntent, current, goNext],
-  );
-
-  const pickCompBand = useCallback(
-    (band: { min: number; max: number }) => {
-      if (current !== 'comp') return;
-      commitIntent({ compRange: { min: band.min, max: band.max, currency: 'SAR', period: 'month' } });
-      goNext('comp');
     },
     [commitIntent, current, goNext],
   );
@@ -301,22 +279,6 @@ export default function OnboardingChat({ path: pathProp, mode = 'fullscreen', on
           ))}
         </div>
       )}
-      {current === 'comp' && (
-        <div className="flex flex-wrap justify-center gap-2">
-          {COMP_BANDS.map((b) => (
-            <button
-              key={b.label}
-              type="button"
-              disabled={busy}
-              onClick={() => pickCompBand(b)}
-              className="rounded-full border border-emerald-500/40 px-4 py-2 text-sm text-emerald-300 active:scale-95 disabled:opacity-50"
-            >
-              {b.label} SAR/mo
-            </button>
-          ))}
-        </div>
-      )}
-
       {/* Plain text input — keyboard mic supplies voice */}
       <textarea
         value={text}

--- a/src/components/onboarding/__tests__/OnboardingChat.inline.test.tsx
+++ b/src/components/onboarding/__tests__/OnboardingChat.inline.test.tsx
@@ -29,11 +29,8 @@ describe('OnboardingChat — inline (Path A) mode', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('advances role -> comp -> location with Skip without any AI call', () => {
+  it('advances role -> location with Skip without any AI call', () => {
     render(<OnboardingChat path="has_cv" mode="inline" />);
-
-    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
-    expect(screen.getByText('What salary are you after?')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
     expect(screen.getByText('Where do you want to work?')).toBeInTheDocument();
@@ -43,8 +40,7 @@ describe('OnboardingChat — inline (Path A) mode', () => {
     const onComplete = vi.fn();
     render(<OnboardingChat path="has_cv" mode="inline" onComplete={onComplete} />);
 
-    // role -> comp -> location -> done
-    fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
+    // role -> location -> done
     fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
     fireEvent.click(screen.getByRole('button', { name: /^skip$/i }));
 

--- a/src/lib/onboarding/__tests__/flow.test.ts
+++ b/src/lib/onboarding/__tests__/flow.test.ts
@@ -36,13 +36,13 @@ describe('onboarding flow state machine', () => {
       const s: OnboardingState = {
         path: 'has_cv',
         current: 'location',
-        answered: { cv_basics: true, role: true, comp: true, location: true },
+        answered: { cv_basics: true, role: true, location: true },
       };
       expect(nextSlot(s)).toBe('done');
     });
 
     it('ignores answer order and returns the earliest gap', () => {
-      const s: OnboardingState = { path: 'no_cv', current: 'cv_basics', answered: { comp: true } };
+      const s: OnboardingState = { path: 'no_cv', current: 'cv_basics', answered: { location: true } };
       expect(nextSlot(s)).toBe('cv_basics');
     });
   });
@@ -76,14 +76,14 @@ describe('onboarding flow state machine', () => {
       let s = initialState('has_cv');
       s = advance(s, 'cv_basics'); // answered with a value
       s = advance(s, 'role'); // skipped
-      expect(s.current).toBe('comp');
+      expect(s.current).toBe('location');
     });
   });
 
   describe('progress', () => {
     it('counts answered vs total slots', () => {
       const s = advance(initialState('has_cv'), 'cv_basics');
-      expect(progress(s)).toEqual({ answered: 1, total: 4 });
+      expect(progress(s)).toEqual({ answered: 1, total: 3 });
     });
   });
 

--- a/src/lib/onboarding/flow.ts
+++ b/src/lib/onboarding/flow.ts
@@ -4,10 +4,10 @@
 import type { OnboardingPath, OnboardingSlot, OnboardingState } from '@/types/onboarding';
 
 /**
- * Canonical slot order. Both paths walk the same four slots; the path difference is
+ * Canonical slot order. Both paths walk the same three slots; the path difference is
  * what `cv_basics` means in the UI (confirm vs input) and the terminal action.
  */
-export const SLOT_SEQUENCE: readonly OnboardingSlot[] = ['cv_basics', 'role', 'comp', 'location'];
+export const SLOT_SEQUENCE: readonly OnboardingSlot[] = ['cv_basics', 'role', 'location'];
 
 /** Fresh machine for a path, starting at the first slot with nothing answered. */
 export function initialState(path: OnboardingPath): OnboardingState {
@@ -16,7 +16,7 @@ export function initialState(path: OnboardingPath): OnboardingState {
 
 /**
  * The next slot to ask: the earliest slot in canonical order not yet answered, or
- * 'done' when all four are handled. Order-independent so the machine stays correct
+ * 'done' when all three are handled. Order-independent so the machine stays correct
  * even if slots are answered out of sequence.
  */
 export function nextSlot(state: OnboardingState): OnboardingSlot | 'done' {

--- a/src/lib/stores/resumeStore.ts
+++ b/src/lib/stores/resumeStore.ts
@@ -79,8 +79,7 @@ const computeCompleteness = (resume: ResumeSchema | null, intent: SearchIntent |
   if (resume?.basics?.label?.trim()) score += 15;
   if ((resume?.work?.length ?? 0) > 0 || (resume?.projects?.length ?? 0) > 0) score += 25;
   if ((intent?.targetRoles?.length ?? 0) > 0) score += 20;
-  if (intent?.compRange) score += 10;
-  if (intent?.location) score += 10;
+  if (intent?.location) score += 20;
   return Math.min(100, score);
 };
 

--- a/src/lib/validation/store-schemas.ts
+++ b/src/lib/validation/store-schemas.ts
@@ -127,12 +127,6 @@ export const ResumeZodSchema = z.object({
 export const SearchIntentSchema = z.object({
     targetRoles: z.array(z.string()).default([]),
     seniority: z.enum(['junior', 'mid', 'senior', 'lead', 'manager']).optional(),
-    compRange: z.object({
-        min: z.number(),
-        max: z.number(),
-        currency: z.string(),
-        period: z.enum(['month', 'year']),
-    }).optional(),
     location: z.object({
         city: z.string().optional(),
         country: z.string().optional(),

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -571,7 +571,7 @@ export const onboardExtract = async ({ slot, userText, currentIntent, signal } =
   return { value: data.value || {}, confidence: data.confidence || 'low' };
 };
 
-export const optimizeResume = async ({ resumeText, jobDesc, mode, preview, language = 'en', workHistory, userClarifications, userHardStops, searchIntent = null, freePreview = false }) => {
+export const optimizeResume = async ({ resumeText, jobDesc, mode, preview, language = 'en', workHistory, userClarifications, userHardStops, freePreview = false }) => {
   if (isCircuitOpen('openrouter-ai')) {
     throw new Error('AI service is experiencing high load. Please wait 30 seconds and try again.');
   }
@@ -582,7 +582,7 @@ export const optimizeResume = async ({ resumeText, jobDesc, mode, preview, langu
       const response = await fetch(OPTIMIZE_ENDPOINT, {
         method: "POST",
         headers,
-        body: JSON.stringify({ resumeText, jobText: jobDesc, mode, preview, language, workHistory, userClarifications, userHardStops, searchIntent, ...(freePreview ? { freePreview } : {}) }),
+        body: JSON.stringify({ resumeText, jobText: jobDesc, mode, preview, language, workHistory, userClarifications, userHardStops, ...(freePreview ? { freePreview } : {}) }),
       });
 
       const data = await handleResponse(response);
@@ -735,12 +735,12 @@ export const generateClarifications = async ({ resumeText, jobDesc, language = '
  * @param {function} onStatus - Callback for status events: (phase: string, extra?: object) => void
  * @returns {Promise<object>} - Same response shape as optimizeResume
  */
-export const optimizeResumeStream = async ({ resumeText, jobDesc, mode, preview, language = 'en', workHistory, userClarifications, userHardStops, searchIntent = null, cacheOnly = false, freePreview = false }, onStatus) => {
+export const optimizeResumeStream = async ({ resumeText, jobDesc, mode, preview, language = 'en', workHistory, userClarifications, userHardStops, cacheOnly = false, freePreview = false }, onStatus) => {
   if (isCircuitOpen('openrouter-ai')) {
     throw new Error('AI service is experiencing high load. Please wait 30 seconds and try again.');
   }
 
-  const requestPayload = { resumeText, jobText: jobDesc, mode, preview, language, workHistory, userClarifications, userHardStops, searchIntent, ...(freePreview ? { freePreview } : {}) };
+  const requestPayload = { resumeText, jobText: jobDesc, mode, preview, language, workHistory, userClarifications, userHardStops, ...(freePreview ? { freePreview } : {}) };
   const recoverFromCacheOnly = async () => {
     if (cacheOnly) return null;
     try {
@@ -753,7 +753,6 @@ export const optimizeResumeStream = async ({ resumeText, jobDesc, mode, preview,
         workHistory,
         userClarifications,
         userHardStops,
-        searchIntent,
         freePreview,
         cacheOnly: true,
       }, onStatus);

--- a/src/services/api.test.js
+++ b/src/services/api.test.js
@@ -469,7 +469,7 @@ describe('optimizeResume', () => {
         headers: expect.objectContaining({
           'Content-Type': 'application/json'
         }),
-        body: JSON.stringify({ resumeText: 'resume', jobText: 'job', language: 'en', searchIntent: null })
+        body: JSON.stringify({ resumeText: 'resume', jobText: 'job', language: 'en' })
       })
     );
     expect(result.source).toBe('gemini');

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -1,22 +1,23 @@
 // src/types/onboarding.ts
 // Conversational onboarding types. `SearchIntent` is the one new canonical-profile
-// slice — target role / comp / location are job-search intent and do not live in a
-// resume. Everything else onboarding produces populates the existing resumeStore.
+// slice — target role / location are job-search intent and do not live in a resume.
+// Everything else onboarding produces populates the existing resumeStore.
+//
+// Scope note: salary/comp was dropped entirely (didn't feed anything downstream —
+// no display, no tailoring signal, just a sensitive question with no payoff). Role
+// and location are collected but are NOT injected into the optimize prompt: the
+// endpoint always requires a job description, which already dominates tailoring, so
+// there is no "no-JD" case that would justify biasing the AI call with stated intent.
+// Role still drives the no-CV starter-CV path and remains stored as profile-level
+// signal for future personalization (item 2).
 
 /**
  * Job-search intent captured during onboarding. Persisted under `watheq:searchIntent`
- * and stored server-side in `resumes.search_intent` (jsonb). Read by the optimize
- * endpoint so the stored profile actually changes per-job tailoring output.
+ * and stored server-side in `resumes.search_intent` (jsonb).
  */
 export interface SearchIntent {
   targetRoles: string[]; // ["Senior Frontend Engineer"]
   seniority?: 'junior' | 'mid' | 'senior' | 'lead' | 'manager';
-  compRange?: {
-    min: number;
-    max: number;
-    currency: string; // "SAR"
-    period: 'month' | 'year';
-  };
   location?: {
     city?: string;
     country?: string; // "SA"
@@ -34,7 +35,7 @@ export interface SearchIntent {
  * confirm step on Path A (name/title already parsed) and an input step on Path B
  * (name + 1-2 achievements typed by hand).
  */
-export type OnboardingSlot = 'cv_basics' | 'role' | 'comp' | 'location';
+export type OnboardingSlot = 'cv_basics' | 'role' | 'location';
 
 export type OnboardingPath = 'has_cv' | 'no_cv';
 

--- a/supabase/migrations/20260630000000_add_search_intent.sql
+++ b/supabase/migrations/20260630000000_add_search_intent.sql
@@ -1,6 +1,5 @@
--- Onboarding: persist job-search intent (target role / comp / location) on the
--- resume row. Read by the optimize endpoint so the stored profile changes per-job
--- tailoring output. See docs/onboarding-v1.md (item 1).
+-- Onboarding: persist job-search intent (target role / location) on the resume row.
+-- See docs/onboarding-v1.md (item 1).
 --
 -- DO NOT auto-apply. Run this in the Supabase dashboard SQL editor.
 


### PR DESCRIPTION
Post-merge trim of item 1 (already on `main` via #114). Keeps only the parts that pay off; removes the two that didn't.

## Removed
- **Salary/comp slot — entirely.** Fed nothing downstream (no display, no tailoring signal) — a sensitive question with no payoff. Gone from the type, both Zod schemas, `flow.ts` sequence, `onboard-extract` schema/instructions, and the `OnboardingChat` UI (COMP_BANDS chips + copy + handlers).
- **searchIntent → optimize injection — entirely** (role + seniority + location, not just location). `optimize` / `optimize-stream` always require a job description, so there is no "no-JD" case where stated intent would help; the JD already dominates tailoring. Removed the `target_search_intent` prompt block and the `searchIntent` plumbing through `optimize.ts`, `optimize-stream.ts`, `gemini-client.js`, `api.js`, and `MainContent` call sites (+ cache-key entries).

## Kept
- `role` + `location` collection. Role still drives the **no-CV starter-CV path** (the real win for someone with no resume) and both stay stored as profile-level signal for item 2. Slots are now `cv_basics → role → location`.
- Guest→sign-in flush, first-run gate, Path-A inline panel — all still work, minus salary.
- **Anti-inflation scoring rubric untouched.**

## Verification
- TypeScript (client + netlify) clean; ESLint clean (also fixed a pre-existing `no-extra-boolean-cast` in `App.tsx`).
- All trim-touched suites green: 86/86 across onboarding, MainContent, optimize, optimize-stream, api, onboard-extract.

## Pre-existing failure — NOT from this PR
`src/__tests__/App.navigation.test.tsx` fails with "useAuth must be used within an AuthProvider". Confirmed present on pristine `origin/main` (verified via stash) — a stale test gap from when `useAuth()` was added to `App.tsx`. Left untouched here; flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
