### PR TITLE
test(app): mock useAuth in App.navigation test

### DIFF
--- a/src/__tests__/App.navigation.test.tsx
+++ b/src/__tests__/App.navigation.test.tsx
@@ -75,6 +75,12 @@ vi.mock('../components/Layout/Header', () => ({
   },
 }));
 
+// App calls useAuth() at the top; without a provider it throws. Mirror the mock the
+// other App-rendering tests use (App.onboarding, MainContent).
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ user: null, loading: false, signInWithGoogle: vi.fn() }),
+}));
+
 vi.mock('../components/Layout/MainContent', () => ({
   default: () => <main>Workspace</main>,
 }));


### PR DESCRIPTION
Fixes a pre-existing failure on `main`: all 4 tests in `src/__tests__/App.navigation.test.tsx` throw `Error: useAuth must be used within an AuthProvider`.

## Cause
`App.tsx` calls `useAuth()` at the top (added with the onboarding guest-mode gate). The navigation test renders `<App />` but never mocks `../hooks/useAuth` or wraps in `AuthProvider`, so every render throws.

## Fix
Add the same `useAuth` mock the other App-rendering tests already use (`App.onboarding.test.tsx`, `MainContent.test.jsx`):
```ts
vi.mock('../hooks/useAuth', () => ({
  useAuth: () => ({ user: null, loading: false, signInWithGoogle: vi.fn() }),
}));
```

Test-only, 6 lines. Independent of the scope-trim PR #117.

## Verification
`npx vitest run src/__tests__/App.navigation.test.tsx src/__tests__/App.onboarding.test.tsx` → 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
