### PR TITLE
fix(credits): release the initial grant from the client

### DIFF
--- a/netlify/functions/__tests__/credit-gate-email-verification.test.ts
+++ b/netlify/functions/__tests__/credit-gate-email-verification.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Every credit-gated handler must derive email verification through
+ * `isEmailVerified`, which is `Boolean(user?.email_confirmed_at)`.
+ *
+ * Comparing the field directly (`user?.email_confirmed_at !== null`) reads as
+ * "verified" whenever the field is absent or the user object is missing, since
+ * `undefined !== null`. That silently disables the anti-abuse gate on the
+ * initial credit grant, which is the exact check plan 007 restored.
+ */
+const creditGatedHandlers = [
+  'ai-match.ts',
+  'generate-cover-letter.ts',
+  'optimize.ts',
+  'optimize-stream.ts',
+  'predict-questions.ts',
+  'vision2030-alignment.ts',
+];
+
+const sources = creditGatedHandlers.map((fileName) => [
+  fileName,
+  readFileSync(resolve(__dirname, '..', fileName), 'utf-8'),
+] as const);
+
+describe('credit-gated handlers derive email verification safely', () => {
+  it.each(sources)('%s imports isEmailVerified from credit-manager', (_fileName, source) => {
+    expect(source).toMatch(/import\s*\{[^}]*\bisEmailVerified\b[^}]*\}\s*from\s*["']\.\.\/lib\/credit-manager\.js["']/);
+  });
+
+  it.each(sources)('%s uses isEmailVerified() to build emailVerified', (_fileName, source) => {
+    expect(source).toMatch(/const\s+emailVerified\s*=\s*isEmailVerified\(/);
+  });
+
+  it.each(sources)('%s never compares email_confirmed_at directly', (_fileName, source) => {
+    expect(source).not.toMatch(/email_confirmed_at\s*(!==|===|!=|==)/);
+  });
+});

--- a/netlify/functions/__tests__/user-credits.test.ts
+++ b/netlify/functions/__tests__/user-credits.test.ts
@@ -1,0 +1,145 @@
+import type { HandlerEvent, HandlerResponse } from '@netlify/functions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getUserCreditsMock, getUserMock } = vi.hoisted(() => ({
+  getUserCreditsMock: vi.fn(),
+  getUserMock: vi.fn(),
+}));
+
+vi.mock('../../lib/rate-limiter.js', () => ({
+  withRateLimit: (_name: string, handler: unknown) => handler,
+}));
+
+vi.mock('../../lib/supabase-client.js', () => ({
+  getSupabaseClient: vi.fn(() => ({ auth: { getUser: getUserMock } })),
+}));
+
+vi.mock('../../lib/credit-manager.js', () => ({
+  getUserCredits: getUserCreditsMock,
+  isEmailVerified: (user: { email_confirmed_at?: string | null } | null) => Boolean(user?.email_confirmed_at),
+}));
+
+vi.mock('../../lib/ip-utils.js', () => ({
+  getClientIP: vi.fn(() => '203.0.113.5'),
+}));
+
+vi.mock('../../lib/sentry.js', () => ({
+  initSentry: vi.fn(),
+  captureError: vi.fn(),
+  summarizeErrorForLog: vi.fn((error: unknown) => (error instanceof Error ? error.message : String(error))),
+}));
+
+const { handler } = await import('../user-credits.js');
+
+const invoke = async (
+  headers: Record<string, string> = { authorization: 'Bearer token' },
+  httpMethod = 'POST',
+): Promise<HandlerResponse> => {
+  const event = { httpMethod, headers, body: '{}' } as unknown as HandlerEvent;
+  return (await handler(event, {} as never)) as HandlerResponse;
+};
+
+const parseBody = (response: HandlerResponse) => JSON.parse(response.body ?? '{}');
+
+const verifiedUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  email_confirmed_at: '2026-07-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUserMock.mockResolvedValue({ data: { user: verifiedUser }, error: null });
+});
+
+describe('user-credits handler', () => {
+  it('rejects non-POST requests', async () => {
+    const response = await invoke({ authorization: 'Bearer token' }, 'GET');
+
+    expect(response.statusCode).toBe(405);
+    expect(getUserCreditsMock).not.toHaveBeenCalled();
+  });
+
+  it('requires an Authorization header', async () => {
+    const response = await invoke({});
+
+    expect(response.statusCode).toBe(401);
+    expect(getUserCreditsMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid session', async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: { message: 'bad token' } });
+
+    const response = await invoke();
+
+    expect(response.statusCode).toBe(401);
+    expect(getUserCreditsMock).not.toHaveBeenCalled();
+  });
+
+  it('releases a pending initial grant and returns the granted balance', async () => {
+    // getUserCredits performs the grant server-side; the flag is cleared by then.
+    getUserCreditsMock.mockResolvedValue({
+      credits_remaining: 20,
+      credits_total: 20,
+      feedback_credits_earned: 0,
+      referral_credits_earned: 0,
+      last_reset_date: '2026-07-23T00:00:00.000Z',
+      signup_metadata: { pending_initial_grant: false },
+    });
+
+    const response = await invoke();
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response)).toEqual({
+      creditsRemaining: 20,
+      creditsTotal: 20,
+      feedbackCreditsEarned: 0,
+      referralCreditsEarned: 0,
+      lastResetDate: '2026-07-23T00:00:00.000Z',
+      pendingInitialGrant: false,
+      emailVerified: true,
+    });
+    expect(getUserCreditsMock).toHaveBeenCalledWith('user@example.com', {
+      ipAddress: '203.0.113.5',
+      emailVerified: true,
+    });
+  });
+
+  it('reports a still-pending grant for an unverified email', async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: { ...verifiedUser, email_confirmed_at: null } },
+      error: null,
+    });
+    getUserCreditsMock.mockResolvedValue({
+      credits_remaining: 0,
+      credits_total: 0,
+      feedback_credits_earned: 0,
+      referral_credits_earned: 0,
+      last_reset_date: '2026-07-23T00:00:00.000Z',
+      signup_metadata: { pending_initial_grant: true },
+    });
+
+    const response = await invoke();
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response)).toMatchObject({
+      creditsRemaining: 0,
+      pendingInitialGrant: true,
+      emailVerified: false,
+    });
+    expect(getUserCreditsMock).toHaveBeenCalledWith('user@example.com', {
+      ipAddress: '203.0.113.5',
+      emailVerified: false,
+    });
+  });
+
+  it('returns a generic 500 without leaking the underlying error', async () => {
+    getUserCreditsMock.mockRejectedValue(new Error('connect ECONNREFUSED db.internal:5432'));
+
+    const response = await invoke();
+
+    expect(response.statusCode).toBe(500);
+    expect(parseBody(response)).toEqual({ error: 'Failed to retrieve credit balance' });
+    expect(response.body).not.toContain('ECONNREFUSED');
+  });
+});

--- a/netlify/functions/ai-match.ts
+++ b/netlify/functions/ai-match.ts
@@ -3,7 +3,7 @@ import { processMatchOnly } from "../lib/gemini-client.js";
 import { checkFreePreviewRateLimit, withRateLimit } from "../lib/rate-limiter.js";
 import { MatchRequestSchema, formatZodError } from "../lib/resume-schemas.js";
 import { initSentry, captureError, summarizeErrorForLog } from "../lib/sentry.js";
-import { checkCredits, consumeCredits } from "../lib/credit-manager.js";
+import { checkCredits, consumeCredits, isEmailVerified } from "../lib/credit-manager.js";
 import { getClientIP } from "../lib/ip-utils.js";
 import { getSupabaseClient } from "../lib/supabase-client.js";
 import { normalizeScore } from "../lib/score-utils.js";
@@ -68,7 +68,7 @@ const baseHandler: Handler = async (event) => {
 
   // Extract IP and email verification for anti-abuse checks
   const ipAddress = getClientIP(event);
-  const emailVerified = user?.email_confirmed_at !== null;
+  const emailVerified = isEmailVerified(user);
 
   if (freePreview) {
     const previewLimit = await checkFreePreviewRateLimit(event, "ai-match-free-preview", user?.id || userEmail);

--- a/netlify/functions/user-credits.ts
+++ b/netlify/functions/user-credits.ts
@@ -1,0 +1,89 @@
+import { Handler } from '@netlify/functions';
+import { getUserCredits, isEmailVerified } from '../lib/credit-manager.js';
+import { getClientIP } from '../lib/ip-utils.js';
+import { withRateLimit } from '../lib/rate-limiter.js';
+import { initSentry, captureError, summarizeErrorForLog } from '../lib/sentry.js';
+import { getSupabaseClient } from '../lib/supabase-client.js';
+
+initSentry();
+
+const headers = { 'Content-Type': 'application/json' };
+
+/**
+ * Authoritative credit balance for the signed-in user.
+ *
+ * The client normally reads `user_credits` directly through RLS, but a row
+ * carrying `signup_metadata.pending_initial_grant` has a zero balance until the
+ * server issues the grant. Only `getUserCredits` can issue it (it runs the
+ * IP-abuse and email-verification checks), so the client cannot resolve that
+ * state on its own — without this endpoint a pending user sees zero credits,
+ * every credit-gated action stays disabled, and no server call is ever made to
+ * release the grant.
+ */
+const baseHandler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  const authHeader = event.headers.authorization || event.headers.Authorization;
+  if (!authHeader) {
+    return {
+      statusCode: 401,
+      headers,
+      body: JSON.stringify({ error: 'Authentication required. Please sign in.' }),
+    };
+  }
+
+  const token = authHeader.replace(/^Bearer\s+/i, '');
+  const client = getSupabaseClient();
+  if (!client) {
+    return {
+      statusCode: 503,
+      headers,
+      body: JSON.stringify({ error: 'Service temporarily unavailable' }),
+    };
+  }
+
+  const { data: { user }, error: authError } = await client.auth.getUser(token);
+  if (authError || !user?.email) {
+    return {
+      statusCode: 401,
+      headers,
+      body: JSON.stringify({ error: 'Invalid or expired authentication token' }),
+    };
+  }
+
+  try {
+    const credits = await getUserCredits(user.email, {
+      ipAddress: getClientIP(event),
+      emailVerified: isEmailVerified(user),
+    });
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        creditsRemaining: credits?.credits_remaining ?? 0,
+        creditsTotal: credits?.credits_total ?? 0,
+        feedbackCreditsEarned: credits?.feedback_credits_earned ?? 0,
+        referralCreditsEarned: credits?.referral_credits_earned ?? 0,
+        lastResetDate: credits?.last_reset_date ?? null,
+        // Still pending means the grant was withheld — currently only when the
+        // email is unverified. The client uses this to explain the zero balance.
+        pendingInitialGrant: credits?.signup_metadata?.pending_initial_grant === true,
+        emailVerified: isEmailVerified(user),
+      }),
+    };
+  } catch (error) {
+    console.error('[user-credits] Failed to resolve credits:', summarizeErrorForLog(error));
+    captureError(error, { function: 'user-credits', userId: user.id });
+
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'Failed to retrieve credit balance' }),
+    };
+  }
+};
+
+export const handler = withRateLimit('user-credits', baseHandler);

--- a/netlify/lib/credit-manager.js
+++ b/netlify/lib/credit-manager.js
@@ -94,7 +94,7 @@ function createCreditManagerError(status, code, message) {
  * @param {Object} options - Additional options
  * @param {string} options.ipAddress - User's IP address for abuse detection
  * @param {boolean} options.emailVerified - Whether user's email is verified
- * @returns {Promise<{credits_remaining: number, credits_total: number, last_reset_date: string} | null>}
+ * @returns {Promise<{credits_remaining: number, credits_total: number, feedback_credits_earned: number, referral_credits_earned: number | null, last_reset_date: string, signup_metadata: ({pending_initial_grant?: boolean} | null)} | null>}
  */
 export async function getUserCredits(email, options = {}) {
   const { ipAddress, emailVerified } = options;

--- a/src/contexts/CreditsContext.tsx
+++ b/src/contexts/CreditsContext.tsx
@@ -29,6 +29,15 @@ interface UserCreditsRow {
     feedback_credits_earned: number;
     referral_credits_earned: number | null;
     last_reset_date: string;
+    signup_metadata: { pending_initial_grant?: boolean } | null;
+}
+
+interface UserCreditsApiResponse {
+    creditsRemaining: number;
+    creditsTotal: number;
+    feedbackCreditsEarned: number;
+    referralCreditsEarned: number;
+    lastResetDate: string | null;
 }
 
 interface CreditsCacheEntry {
@@ -55,6 +64,43 @@ const getDefaultCredits = (): UserCredits => ({
     resetDate: new Date().toISOString(),
 });
 
+/**
+ * A row flagged `pending_initial_grant` always reads as zero credits: the signup
+ * trigger creates it empty and only the server may issue the grant, after its
+ * IP-abuse and email-verification checks. Reading the table alone would leave a
+ * new user at zero with every credit-gated action disabled, so resolve the grant
+ * server-side and use that balance instead. Failure is non-fatal — the caller
+ * falls back to the (zero) row rather than erroring the whole provider.
+ */
+const resolvePendingInitialGrant = async (fallback: UserCredits): Promise<UserCredits> => {
+    try {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session?.access_token) return fallback;
+
+        const response = await fetch('/.netlify/functions/user-credits', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${session.access_token}`,
+            },
+        });
+
+        if (!response.ok) return fallback;
+
+        const data = await response.json() as UserCreditsApiResponse;
+        return {
+            remaining: data.creditsRemaining,
+            total: data.creditsTotal,
+            feedbackCreditsEarned: data.feedbackCreditsEarned,
+            referralCreditsEarned: data.referralCreditsEarned,
+            resetDate: data.lastResetDate ?? fallback.resetDate,
+        };
+    } catch (error) {
+        console.warn('[CreditsContext] Failed to resolve initial credit grant:', error);
+        return fallback;
+    }
+};
+
 const fetchCreditsForEmail = (email: string, options: { forceRefresh?: boolean } = {}) => {
     const cached = recentCreditsByEmail.get(email);
     if (!options.forceRefresh && cached && Date.now() - cached.fetchedAt < CREDITS_CACHE_TTL_MS) {
@@ -68,7 +114,7 @@ const fetchCreditsForEmail = (email: string, options: { forceRefresh?: boolean }
 
     const request = Promise.resolve(supabase
         .from('user_credits')
-        .select('credits_remaining, credits_total, feedback_credits_earned, referral_credits_earned, last_reset_date')
+        .select('credits_remaining, credits_total, feedback_credits_earned, referral_credits_earned, last_reset_date, signup_metadata')
         .eq('email', email)
         .single())
         .then(({ data, error: fetchError }) => {
@@ -83,7 +129,14 @@ const fetchCreditsForEmail = (email: string, options: { forceRefresh?: boolean }
                 return getDefaultCredits();
             }
 
-            return mapCreditsRow(data as UserCreditsRow);
+            const row = data as UserCreditsRow;
+            const credits = mapCreditsRow(row);
+
+            if (row.signup_metadata?.pending_initial_grant === true) {
+                return resolvePendingInitialGrant(credits);
+            }
+
+            return credits;
         })
         .then((credits) => {
             recentCreditsByEmail.set(email, { fetchedAt: Date.now(), credits });


### PR DESCRIPTION
Stacked on #126. Fixes a blocker found while reviewing that branch: **applying plan 007's migration would have permanently stranded every new signup at zero credits, even with the code deployed first.**

## The deadlock

Plan 007 moves the initial credit grant off the signup trigger. The trigger now creates the `user_credits` row empty, flagged `signup_metadata.pending_initial_grant`, and the real grant is issued server-side by `getUserCredits` once its IP-abuse and email-verification checks pass.

Nothing on the client could reach that code path:

1. `CreditsContext` reads `user_credits` directly through RLS, so a pending user reads as **0 credits**.
2. `ConfirmActionModal` computes `canProceed = currentCredits >= cost` from that balance and does not render the confirm button when it is false. All five paid features (`optimize`, `ai_match`, `vision2030`, `interview_prep`, `cover_letter`) are gated by it.
3. The only zero-cost feature, `parse_resume`, never calls `checkCredits`.

So a new user could not trigger any server call that reaches `getUserCredits` — the grant could never fire, and the account stayed at zero forever. This is not a pre-deploy window problem; it persists after deploy, which is why the deploy-order note on #126 was not sufficient on its own.

## The fix

- New `netlify/functions/user-credits.ts`: authenticates the caller and resolves the balance through `getUserCredits`, which issues the grant as a side effect. Rate-limited, generic error envelope, no raw error text returned.
- `CreditsContext` now selects `signup_metadata` and calls that endpoint **only** when `pending_initial_grant` is set. Existing users are unaffected beyond one extra column in the select. If the call fails, it falls back to the row rather than erroring the whole provider.

## Second bug: anti-abuse bypass in ai-match

`ai-match.ts` built `emailVerified` as `user?.email_confirmed_at !== null`. Since `undefined !== null` is `true`, that reads as **verified** whenever the field is absent — silently disabling the email gate that plan 007 restored. Every other credit-gated handler uses the shared `isEmailVerified` helper (`Boolean(user?.email_confirmed_at)`); `ai-match` now does too.

Added `credit-gate-email-verification.test.ts`, a source-level guard pinning all six credit-gated handlers to import and use the helper and never compare `email_confirmed_at` directly.

Also corrected the JSDoc return type on `getUserCredits`, which listed three of the six columns it actually selects.

## Verification

- `npm run lint` — no issues
- `npm run type:check` — clean
- `npm run test` — 171 files, 1591 passed, 2 skipped, 0 failed

Note: unit tests alone would not have caught this bug — it is a wiring gap between a server-side grant and a client-side read. The real signup to grant to display flow should be exercised against the deploy preview before the migration is applied.

## Required ordering

1. Merge this into #126, then merge #126 into `main`.
2. Confirm the Netlify **production** deploy is live.
3. Verify a real verified-email signup receives credits.
4. Only then apply `supabase/migrations/20260721000000_initial_grant_anti_abuse.sql`.

Applying that migration before step 3 will break new signups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
