### PR TITLE
fix(db): record credit transactions that were failing to insert

### DIFF
--- a/supabase/migrations/20260721000000_initial_grant_anti_abuse.sql
+++ b/supabase/migrations/20260721000000_initial_grant_anti_abuse.sql
@@ -72,8 +72,13 @@ begin
     updated_at = now()
   where email = p_email;
 
+  -- `feature` is NOT NULL. Non-consumption rows repeat the transaction type
+  -- there, matching the existing feedback_reward / referral_reward entries.
+  -- 'initial_grant' is only accepted once 20260723000000 widens the
+  -- transaction_type CHECK, so apply that migration together with this one.
   insert into public.credit_transactions (
     email,
+    feature,
     transaction_type,
     credits_before,
     credits_after,
@@ -81,6 +86,7 @@ begin
     metadata
   ) values (
     p_email,
+    'initial_grant',
     'initial_grant',
     v_current_remaining,
     p_amount,

--- a/supabase/migrations/20260723000000_fix_credit_transaction_writes.sql
+++ b/supabase/migrations/20260723000000_fix_credit_transaction_writes.sql
@@ -1,0 +1,103 @@
+-- Repair two long-standing defects in how credits are written.
+-- Created: 2026-07-23
+-- Note: Run this in the Supabase dashboard SQL editor.
+--
+-- 1. `credit_transactions.feature` is NOT NULL, but `add_credits` never supplied
+--    it. Every call therefore failed with 23502, so no reward, refund or bonus
+--    routed through the RPC was ever recorded — including the referral payouts
+--    that plan 008 moved onto it.
+--
+-- 2. `transaction_type_check` allowed only consumption / referral_reward /
+--    feedback_reward / monthly_reset, while the application also writes
+--    'refund' (the optimize, optimize-stream and vision2030 fail-safes),
+--    'reset' (cron-reset-credits), 'celebration_bonus' (dev tool) and
+--    'initial_grant' (plan 007). Those inserts failed with 23514; refunds in
+--    particular were silently dropped.
+--
+-- Both were verified against production by calling the RPCs directly.
+
+begin;
+
+alter table public.credit_transactions
+  drop constraint if exists transaction_type_check;
+
+alter table public.credit_transactions
+  add constraint transaction_type_check check (
+    transaction_type = any (array[
+      'consumption'::text,
+      'referral_reward'::text,
+      'feedback_reward'::text,
+      'monthly_reset'::text,
+      'reset'::text,
+      'refund'::text,
+      'celebration_bonus'::text,
+      'initial_grant'::text
+    ])
+  );
+
+-- Adds the missing `feature` value and takes the row lock the read-modify-write
+-- always needed.
+create or replace function public.add_credits(
+  p_email character varying,
+  p_amount integer,
+  p_description text,
+  p_transaction_type text
+) returns jsonb
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_current_total integer;
+  v_new_total integer;
+  v_current_remaining integer;
+  v_new_remaining integer;
+begin
+  select credits_total, credits_remaining
+  into v_current_total, v_current_remaining
+  from public.user_credits
+  where email = p_email
+  for update;
+
+  if not found then
+    raise exception 'User credits record not found for email: %', p_email;
+  end if;
+
+  v_new_total := v_current_total + p_amount;
+  v_new_remaining := v_current_remaining + p_amount;
+
+  update public.user_credits
+  set
+    credits_total = v_new_total,
+    credits_remaining = v_new_remaining,
+    updated_at = now()
+  where email = p_email;
+
+  insert into public.credit_transactions (
+    email,
+    feature,
+    transaction_type,
+    credits_before,
+    credits_after,
+    amount,
+    metadata
+  ) values (
+    p_email,
+    p_transaction_type,
+    p_transaction_type,
+    v_current_remaining,
+    v_new_remaining,
+    p_amount,
+    jsonb_build_object('description', p_description)
+  );
+
+  return jsonb_build_object(
+    'success', true,
+    'credits_added', p_amount,
+    'total', v_new_total,
+    'remaining', v_new_remaining
+  );
+end;
+$function$;
+
+commit;


### PR DESCRIPTION
Follow-up to #126 / #127. While verifying plan 007's migration against production I found that **several credit writes have never worked** — the SQL had not been executed against the real schema. Both defects are already fixed in the live database; this PR brings the repo migrations in line so a re-run reproduces the working state.

## Defect 1 — `add_credits` could never insert

`credit_transactions.feature` is `NOT NULL`, but `add_credits` never supplied it. Every call failed with `23502`:

```
null value in column "feature" of relation "credit_transactions" violates not-null constraint
```

Nothing routed through that RPC was ever recorded. This matters more after #126, because plan 008 moved referral payouts onto `add_credits` — each attempt would have failed and called `reopenClaimForRetry`, so referral rewards could never be paid.

## Defect 2 — the transaction_type CHECK was too narrow

`transaction_type_check` allowed only `consumption`, `referral_reward`, `feedback_reward`, `monthly_reset`. The application also writes:

| value | written by |
|---|---|
| `refund` | `optimize.ts`, `optimize-stream.ts`, `vision2030-alignment.ts` fail-safes |
| `reset` | `cron-reset-credits.ts` |
| `celebration_bonus` | `dev-celebration-bonus.ts` |
| `initial_grant` | plan 007's `grant_initial_credits` |

Those inserts failed with `23514`. The refund path is the significant one: the post-charge fail-safes added by the security round were never recording their refunds.

## Changes

- `20260723000000_fix_credit_transaction_writes.sql` (new): widens the CHECK to the set the application actually writes, adds the missing `feature` value to `add_credits`, and adds the `FOR UPDATE` row lock its read-modify-write always needed.
- `20260721000000_initial_grant_anti_abuse.sql` (corrected in place): its `credit_transactions` insert omitted `feature` and used a `transaction_type` the CHECK rejected, so the file as merged could not run.

`feature` repeats the transaction type for non-consumption rows, matching the existing `feedback_reward` / `referral_reward` entries.

## Verification (against production)

Each step was run directly and the probe row removed afterwards; the 7 real `user_credits` rows were untouched.

| check | result |
|---|---|
| `grant_initial_credits` first call | `granted=true, credits_remaining=20` |
| same call again (idempotency) | `granted=false, credits_remaining=20` — no double grant |
| `add_credits(..., 'referral_reward')` | `success=true, remaining=25` |
| `add_credits(..., 'refund')` | `success=true, remaining=30` |
| `supabase-rls-migrations` test | 10 passed |

## Follow-up, not changed here

`cron-reset-credits.ts` writes `'reset'` while the rest of the codebase uses `'monthly_reset'`. Both are accepted by the widened CHECK rather than changing cron behaviour in a migration PR; worth reconciling to one value separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
