### PR TITLE
fix: landing-first onboarding + main-thread PDF parsing (upload 422)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,11 @@ const ENABLE_HR_MASCOT = false;
 
 const GUEST_MODE_STORAGE_KEY = "watheq:guestMode";
 const GUEST_MODE_CHANGED_EVENT = "watheq:guestModeChanged";
+// Set once a signed-out visitor leaves the landing page (Get started / guest preview).
+const LANDING_SEEN_STORAGE_KEY = "watheq:landingSeen";
+// Fired by the landing "Get started" CTA when a new signed-out visitor should enter
+// the first-run onboarding chat instead of jumping straight into the guest workspace.
+const ENTER_ONBOARDING_EVENT = "watheq:enter-onboarding";
 
 // Feature-flags dashboard. Reachable in dev always, and in prod for signed-in
 // admins (the page self-gates via app_metadata.role, mirroring AdminFeedbackPage).
@@ -78,7 +83,19 @@ export default function App() {
   );
   const onboardingChatEnabled = useFeatureFlag("onboardingChat");
   const hrOverlayEnabled = useFeatureFlag("hrSuperSaudOverlay");
-  const needsOnboarding = onboardingChatEnabled && onboardingGateActive && !onboardedFlag;
+  // A signed-out visitor sees the landing page FIRST; onboarding opens only after they
+  // click a "Get started" CTA (which fires ENTER_ONBOARDING_EVENT / sets landingSeen).
+  // Signed-in new users are unaffected — they never see the landing page, so their
+  // onboarding still opens on entry.
+  const [enteredApp, setEnteredApp] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(LANDING_SEEN_STORAGE_KEY) === "true";
+  });
+  const needsOnboarding =
+    onboardingChatEnabled &&
+    onboardingGateActive &&
+    !onboardedFlag &&
+    (Boolean(user) || enteredApp);
 
   // Run storage migration once on app initialization
   useEffect(() => {
@@ -97,16 +114,22 @@ export default function App() {
       workspaceScrollYRef.current = window.scrollY;
       setLandingSection(section);
     };
+    const handleEnterOnboarding = () => {
+      window.localStorage.setItem(LANDING_SEEN_STORAGE_KEY, "true");
+      setEnteredApp(true);
+    };
     window.addEventListener("popstate", handleLocationChange);
     window.addEventListener("watheq:navigate", handleLocationChange);
     window.addEventListener(GUEST_MODE_CHANGED_EVENT, handleGuestModeChange);
     window.addEventListener("watheq:view-landing", handleViewLanding);
+    window.addEventListener(ENTER_ONBOARDING_EVENT, handleEnterOnboarding);
 
     return () => {
       window.removeEventListener("popstate", handleLocationChange);
       window.removeEventListener("watheq:navigate", handleLocationChange);
       window.removeEventListener(GUEST_MODE_CHANGED_EVENT, handleGuestModeChange);
       window.removeEventListener("watheq:view-landing", handleViewLanding);
+      window.removeEventListener(ENTER_ONBOARDING_EVENT, handleEnterOnboarding);
     };
   }, []);
 

--- a/src/__tests__/App.navigation.test.tsx
+++ b/src/__tests__/App.navigation.test.tsx
@@ -210,6 +210,9 @@ describe('App compliance navigation', () => {
 
   it('keeps the normal app shell visible after signed-out onboarding enters guest mode', async () => {
     window.localStorage.removeItem('watheq:onboarded');
+    // Signed-out onboarding now opens only after the visitor enters from the landing
+    // page ("Get started"); simulate that so the first-run gate is active.
+    window.localStorage.setItem('watheq:landingSeen', 'true');
 
     render(<App />);
 

--- a/src/__tests__/App.onboarding.test.tsx
+++ b/src/__tests__/App.onboarding.test.tsx
@@ -183,8 +183,23 @@ describe('App onboarding overlay — react-joyride removed', () => {
     expect(uploadButton).toBeEnabled();
   });
 
-  it('shows the first-run onboarding gate when no resume, no intent, and not flagged', () => {
+  it('shows the landing page (not onboarding) on a signed-out visitor\'s first paint', () => {
     window.localStorage.removeItem('watheq:onboarded');
+    // No landingSeen yet: the visitor has not clicked "Get started", so the first-run
+    // onboarding gate must NOT preempt the landing/workspace.
+    window.localStorage.removeItem('watheq:landingSeen');
+    useResumeStore.setState({ originalResume: null, parsedResumeText: null, searchIntent: null });
+
+    render(<App />);
+
+    expect(screen.queryByText('Onboarding')).toBeNull();
+    expect(screen.getByRole('button', { name: /upload resume/i })).toBeInTheDocument();
+  });
+
+  it('shows the first-run onboarding gate once a signed-out visitor has entered (Get started)', () => {
+    window.localStorage.removeItem('watheq:onboarded');
+    // Simulate the visitor clicking "Get started" on the landing page.
+    window.localStorage.setItem('watheq:landingSeen', 'true');
     useResumeStore.setState({ originalResume: null, parsedResumeText: null, searchIntent: null });
 
     render(<App />);
@@ -195,6 +210,7 @@ describe('App onboarding overlay — react-joyride removed', () => {
 
   it('does not leave first-run onboarding after only the starter name answer', async () => {
     window.localStorage.removeItem('watheq:onboarded');
+    window.localStorage.setItem('watheq:landingSeen', 'true');
     useResumeStore.setState({ originalResume: null, parsedResumeText: null, searchIntent: null });
 
     render(<App />);
@@ -208,6 +224,7 @@ describe('App onboarding overlay — react-joyride removed', () => {
   it('marks signed-out first-run completion as guest preview', async () => {
     window.localStorage.removeItem('watheq:onboarded');
     window.localStorage.removeItem('watheq:guestMode');
+    window.localStorage.setItem('watheq:landingSeen', 'true');
     useResumeStore.setState({ originalResume: null, parsedResumeText: null, searchIntent: null });
 
     render(<App />);

--- a/src/__tests__/MainContent.test.jsx
+++ b/src/__tests__/MainContent.test.jsx
@@ -336,8 +336,30 @@ describe("MainContent resume parsing", () => {
     removeItemSpy.mockRestore();
   });
 
-  it("opens guest workspace from the signed-out preview CTA without starting Google sign-in", async () => {
+  it("routes a NEW signed-out visitor into first-run onboarding from the preview CTA (not straight into the guest workspace)", async () => {
     authMockState.user = null;
+    const enterOnboarding = vi.fn();
+    window.addEventListener("watheq:enter-onboarding", enterOnboarding);
+
+    render(<MainContent />);
+
+    expect(localStorage.getItem("watheq:guestMode")).toBeNull();
+    fireEvent.click(await screen.findByRole("button", { name: /preview the workflow/i }));
+
+    // Onboarding is owned by App: MainContent signals it via the event + landingSeen,
+    // and must NOT enter the guest workspace or trigger Google sign-in itself.
+    expect(authMockState.signInWithGoogle).not.toHaveBeenCalled();
+    expect(enterOnboarding).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem("watheq:landingSeen")).toBe("true");
+    expect(localStorage.getItem("watheq:guestMode")).toBeNull();
+    expect(analyticsMock.trackGuestPreviewStarted).toHaveBeenCalledWith("landing_preview");
+
+    window.removeEventListener("watheq:enter-onboarding", enterOnboarding);
+  });
+
+  it("opens the guest workspace directly for an already-onboarded signed-out visitor", async () => {
+    authMockState.user = null;
+    localStorage.setItem("watheq:onboarded", "true");
 
     render(<MainContent />);
 

--- a/src/__tests__/resumeText.test.js
+++ b/src/__tests__/resumeText.test.js
@@ -63,12 +63,18 @@ describe("resume text helpers", () => {
     const buffer = new Uint8Array([1, 2, 3]).buffer;
     const text = await extractPlainTextFromArrayBuffer(buffer, { mimeType: "application/pdf" });
     expect(text).toBe("Hello Riyadh");
-    expect(pdfGetDocument).toHaveBeenCalledWith({
-      data: buffer,
-      cMapUrl: "https://unpkg.com/pdfjs-dist@5.7.284/cmaps/",
-      cMapPacked: true,
-      standardFontDataUrl: "https://unpkg.com/pdfjs-dist@5.7.284/standard_fonts/",
-    });
+    // Main-thread mode: workerSrc is still populated (pdfjs requires it even with
+    // disableWorker), but parsing runs on the main thread with no eval (CSP-safe).
+    // `data` is a private .slice(0) copy, so match by option shape not buffer identity.
+    expect(pdfGetDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        disableWorker: true,
+        isEvalSupported: false,
+        cMapUrl: "https://unpkg.com/pdfjs-dist@5.7.284/cmaps/",
+        cMapPacked: true,
+        standardFontDataUrl: "https://unpkg.com/pdfjs-dist@5.7.284/standard_fonts/",
+      })
+    );
     expect(pdfWorkerOptions.workerSrc).toBe("/assets/pdf.worker.test.mjs");
   });
 

--- a/src/components/Layout/MainContent.tsx
+++ b/src/components/Layout/MainContent.tsx
@@ -25,6 +25,7 @@ import {
 import { useAuth } from "../../hooks/useAuth";
 import UploadSection from "../sections/UploadSection";
 import { isIntentPrompted, markIntentPrompted } from "../../lib/onboarding/intentPromptFlag";
+import { isOnboarded } from "../../lib/onboarding/onboardedFlag";
 // KeywordsSection removed from MVP navigation - functionality merged into Optimize section
 
 // Lazy-loaded tab sections — each gets its own chunk
@@ -502,6 +503,22 @@ export default function MainContent() {
     setGuestMode(true);
     setActiveTab("resume");
   }, []);
+
+  // Landing "Get started" for a signed-out visitor. A brand-new user (onboarding flag
+  // on, not yet onboarded) is routed into the first-run onboarding chat first — App
+  // owns that gate and opens it on the ENTER_ONBOARDING_EVENT. Returning/onboarded
+  // users (or when the flag is off) skip straight into the guest workspace.
+  const handleLandingGetStarted = useCallback(() => {
+    if (flags.onboardingChat && !isOnboarded()) {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("watheq:landingSeen", "true");
+        window.dispatchEvent(new Event("watheq:enter-onboarding"));
+      }
+      analytics.trackGuestPreviewStarted("landing_preview");
+      return;
+    }
+    enterGuestMode();
+  }, [enterGuestMode, flags.onboardingChat]);
 
   const exitGuestMode = useCallback(() => {
     if (typeof window !== "undefined") {
@@ -2318,7 +2335,7 @@ export default function MainContent() {
         <ToastContainer>{renderedToasts}</ToastContainer>
         <Suspense fallback={<SectionSkeleton />}>
           <LandingPage
-            onGetStarted={enterGuestMode}
+            onGetStarted={handleLandingGetStarted}
             onSignIn={() => handleGuestSignIn()}
           />
         </Suspense>

--- a/src/lib/utils/resumeText.ts
+++ b/src/lib/utils/resumeText.ts
@@ -69,6 +69,15 @@ const loadPdfjs = async () => {
   if (pdfjsLibPromise !== undefined) {
     return pdfjsLibPromise;
   }
+  // We still resolve the bundled worker URL so pdfjs has a valid `workerSrc`, but
+  // parsing runs on the MAIN THREAD (`disableWorker: true` at the getDocument call).
+  // pdfjs 5.x REQUIRES a non-empty workerSrc even in no-worker mode (it dynamically
+  // imports that module on the main thread); an empty workerSrc throws "Setting up
+  // fake worker failed". Main-thread mode avoids spawning `new Worker(type:'module')`
+  // and the cross-thread ArrayBuffer transfer — the failure surface implicated by the
+  // prod "detached ArrayBuffer" symptom, where the worker received the buffer then the
+  // real (swallowed) error threw. The worker asset itself serves fine in prod
+  // (application/javascript, 200), so this is NOT a MIME/serving fix.
   pdfjsLibPromise = Promise.all([
     import("pdfjs-dist/legacy/build/pdf.mjs"),
     import("pdfjs-dist/legacy/build/pdf.worker.mjs?url"),
@@ -548,6 +557,11 @@ const extractPdfPlainText = async (arrayBuffer) => {
     try {
       const document = await pdfjs.getDocument({
         data: pdfData,
+        // Parse on the main thread (no worker asset — see loadPdfjs). isEvalSupported
+        // false skips pdfjs's eval-based font path (text extraction never needs it),
+        // keeping this clean under a `script-src 'self'` CSP with no unsafe-eval.
+        disableWorker: true,
+        isEvalSupported: false,
         cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
         cMapPacked: true,
         standardFontDataUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/standard_fonts/`,

--- a/src/lib/utils/resumeText.ts
+++ b/src/lib/utils/resumeText.ts
@@ -539,9 +539,15 @@ const extractPdfTextFallback = (arrayBuffer) => {
 const extractPdfPlainText = async (arrayBuffer) => {
   const pdfjs = await loadPdfjs();
   if (pdfjs) {
+    // pdfjs `getDocument({ data })` transfers ownership of the buffer and DETACHES it.
+    // Hand it a private copy so the raw-text fallback below can still read the original
+    // bytes when the primary path throws — otherwise `new Uint8Array(detachedBuffer)`
+    // in extractPdfTextFallback crashes with "Cannot perform Construct on a detached
+    // ArrayBuffer", turning a recoverable pdfjs failure into an empty extraction (→ 422).
+    const pdfData = arrayBuffer.slice(0);
     try {
       const document = await pdfjs.getDocument({
-        data: arrayBuffer,
+        data: pdfData,
         cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
         cMapPacked: true,
         standardFontDataUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/standard_fonts/`,
@@ -582,8 +588,15 @@ const extractPdfPlainText = async (arrayBuffer) => {
       if (lines.length > 0) {
         return lines.join("\n");
       }
-    } catch {
-      // fall back to manual parsing below
+    } catch (error) {
+      // Surface the real pdfjs failure instead of swallowing it. This is the error
+      // that otherwise hides behind an empty extraction + a generic server 422, so it
+      // is the single most useful signal for diagnosing prod upload regressions
+      // (e.g. worker-asset loading failures that only reproduce on the deployed site).
+      console.error("[ResumeText] pdfjs extraction failed; using raw-text fallback:", error);
+      void import("@sentry/react")
+        .then((Sentry) => Sentry.captureException(error, { tags: { area: "pdf-extract" } }))
+        .catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Summary

Two user-reported prod bugs on watheqai.app.

### 1. Onboarding pops before the landing page (first visit)
`needsOnboarding` (App.tsx) won the render tree and also gated `isSignedOutLanding` (`!needsOnboarding`), so a signed-out first-timer always got the onboarding chat instead of the landing page. Now the landing shows first; the first-run onboarding chat opens only after the visitor clicks a "Get started" CTA (`enteredApp` signal seeded from `watheq:landingSeen`, flipped via the `watheq:enter-onboarding` event). Signed-in new-user path unchanged.

### 2. PDF upload fails → server 422 (`resume/unreadable-file`)
Client-side pdfjs text extraction stopped working for text PDFs after #121 switched pdfjs from no-worker to a real web worker.

Investigated empirically:
- **`curl -I` of the deployed `/assets/pdf.worker-*.mjs` → `200`, `application/javascript`, full 2.3MB.** The worker serves fine — **not** a MIME/serving bug.
- The `Cannot perform Construct on a detached ArrayBuffer` console error means pdfjs transferred the buffer to a worker that ran, then the real error threw and was swallowed by a bare `catch {}`. Failure surface = worker instantiation / cross-thread transfer in the browser.
- A tsx probe against a real FlateDecode PDF confirmed extraction works under `disableWorker:true` + `isEvalSupported:false`. Also confirmed pdfjs **5.7.284 requires a non-empty `workerSrc`** (an inline `workerSrc=""` revert throws `Setting up fake worker failed`).

**Fix:** keep the bundled worker URL (pdfjs needs `workerSrc` populated) but parse on the **main thread** — `disableWorker:true` + `isEvalSupported:false` on `getDocument`. Removes `new Worker(type:'module')` + the cross-thread buffer transfer, and skips the eval-based font path (CSP-safe under `script-src 'self'`). Also keeps the `.slice(0)` buffer copy + un-swallowed error logging so any remaining failure surfaces the real pdfjs error instead of a generic 422.

## Verification
- `tsc --noEmit` clean; `npm run lint` clean; `npm run build` succeeds (worker asset still emits).
- Focused vitest green: `resumeText.test.js` (18), `App.onboarding`, `App.navigation`, `MainContent`.
- Real-PDF extraction proven via tsx probe (a browser Worker can't run in vitest/jsdom).

## Caveat
The worker serves correctly and a generic PDF extracts fine, so the exact throw only reproduces on the reporter's specific file (masked in the deployed build). This fix removes the most-implicated failure class and is strictly safer; if it persists after deploy, the now-surfaced console error / a HAR will name the real cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)