### PR TITLE
fix(models): correct stale pricing + spec the ai_match model re-sweep

### DIFF
--- a/docs/superpowers/specs/2026-07-26-ai-match-model-resweep-design.md
+++ b/docs/superpowers/specs/2026-07-26-ai-match-model-resweep-design.md
@@ -1,0 +1,99 @@
+# ai_match model re-sweep — design
+
+**Date:** 2026-07-26
+**Status:** approved, blocked on prerequisite
+
+## Problem
+
+A 2026-07-26 sweep of the `ai_match_reality_check` gold set concluded that
+`google/gemini-3.5-flash-lite` should replace `google/gemini-2.5-flash`: quality parity at
+identical price ($0.30/$2.50) with 2.5–3x lower latency (median 4.5–5.6s vs 13.5s).
+
+That conclusion is not usable. The sweep ran against a defective `strongMatches` prompt that
+penalised every model tested — the fix (branch `claude/angry-hertz-ba6bb0`) takes baseline
+`gemini-2.5-flash` from 92% mean / 3-of-8 clean to **8/8 @ 100%**. The prompt defect was the
+dominant signal in the measurement, so the model ranking derived from it is unvalidated.
+
+The pin was wired and then reverted. This spec defines the re-measurement that would justify
+re-applying it.
+
+## Prerequisite
+
+The `strongMatches` evidence-rule fix is merged to `main`, and `npm run eval:match` on baseline
+`gemini-2.5-flash` reproduces 8/8 @ 100%.
+
+If it does not reproduce, stop. An unstable gate makes any model comparison meaningless, and the
+instability is the more important finding.
+
+## Method
+
+Extend the existing scratch harness (injects `options.modelId`, requires `OPENROUTER_API_KEY`,
+deletes `GEMINI_API_KEY` so a non-Google model id cannot silently fall back to Gemini under a
+bogus name):
+
+- **3 runs per model.** Report mean plus per-fixture min/max. The harness currently runs each
+  fixture once and reports no spread, while the observed within-model swing
+  (3.5-flash-lite on `arabic-accountant-partial`: 100% → 78% → 78%) is larger than the
+  between-model gaps under comparison.
+- **Record per-fixture latency** alongside score. Latency is the actual thesis of the switch and
+  the eval does not measure it. Report median and p95.
+
+## Candidates
+
+`google/gemini-2.5-flash` (baseline) and `google/gemini-3.5-flash-lite`.
+
+The other five sweep candidates are already excluded on evidence and are not re-run:
+
+| model | exclusion |
+|---|---|
+| `deepseek/deepseek-v4-flash` | uniform 65s timeouts (provider throughput) |
+| `z-ai/glm-4.7-flash` | uniform 65s timeouts (provider throughput) |
+| `qwen/qwen3.5-flash-02-23` | wrapper shape fails Zod on all 4 top-level fields |
+| `mistralai/mistral-small-3.2-24b-instruct` | 65s latency tail |
+| `google/gemini-2.5-flash-lite` | non-Arabic prose on Arabic fixtures — hard product fail (`eval/match-score.mjs:146`) |
+
+## Decision rule
+
+Fixed before seeing data:
+
+**Pin `ai_match_reality_check` to `gemini-3.5-flash-lite` only if it scores 8/8 on all three runs
+AND its p95 latency beats baseline's. Otherwise keep `gemini-2.5-flash`.**
+
+At 8/8 the ceiling settles the quality question — a candidate can tie but not win. The switch then
+rests entirely on latency, which is the honest framing of what is being bought.
+
+## Pin mechanism (if the rule passes)
+
+Restore the reverted shape:
+
+1. `FEATURE_MODEL_PINS` map in `netlify/lib/model-registry.js`, keyed by feature, each entry
+   carrying its eval evidence in a comment.
+2. `modelId: FEATURE_MODEL_PINS.ai_match_reality_check` on the contract in
+   `netlify/lib/ai-contracts/contracts/index.js`. Keep `modelType: 'flash'` so tier token defaults
+   and the direct-Gemini fallback retain their behaviour.
+3. `netlify/lib/ai-contracts/executor.js` — `modelId: options.modelId ?? contract.modelId`.
+   Caller override (evals, benchmarks) still wins.
+4. Update the `[Gemini] Fast match analysis with …` log in `netlify/lib/gemini-client.js`, or it
+   names a model that path no longer calls.
+
+Pin the feature, never `MODELS.flash`: roughly ten features share that tier constant and they
+disagree — this candidate wins match and loses optimize (−1.38 jd_alignment against a 0.09 judge
+noise floor). `ai_match`, the fallback contract used when reality-check throws, is separate and
+was never measured; it stays on the tier default.
+
+## Out of scope
+
+Hardening `eval:match` itself — built-in repeat runs, a latency assertion, more Arabic fixtures
+(currently 1 of 8, and the fixture where candidates wobble). These are real gaps, but changing the
+instrument and taking the measurement in the same pass makes neither trustworthy. Separate work.
+
+## Known eval limits this design works around
+
+`npm run eval:match` is a sound regression gate: deterministic scorer with no LLM judge, exit code
+counts hard failures and invariance-group band crossings (`scripts/match-eval.mjs:185`), missing
+caches hard-error rather than silently skipping. It is not a ranking instrument — hence the 3-run
+requirement and the pre-committed decision rule above.
+
+One operational note: `eval/match-fixtures/*.actual.json` caches are model-dependent and committed.
+After any model change they hold the previous model's output, so a keyless run scores stale data
+while appearing to validate production. Revert or regenerate them deliberately.

--- a/docs/superpowers/specs/2026-07-26-ai-match-model-resweep-design.md
+++ b/docs/superpowers/specs/2026-07-26-ai-match-model-resweep-design.md
@@ -1,7 +1,7 @@
 # ai_match model re-sweep — design
 
 **Date:** 2026-07-26
-**Status:** approved, blocked on prerequisite
+**Status:** approved, prerequisite satisfied
 
 ## Problem
 
@@ -10,7 +10,7 @@ A 2026-07-26 sweep of the `ai_match_reality_check` gold set concluded that
 identical price ($0.30/$2.50) with 2.5–3x lower latency (median 4.5–5.6s vs 13.5s).
 
 That conclusion is not usable. The sweep ran against a defective `strongMatches` prompt that
-penalised every model tested — the fix (branch `claude/angry-hertz-ba6bb0`) takes baseline
+penalised every model tested — `73f72a4` (merged through #131) takes baseline
 `gemini-2.5-flash` from 92% mean / 3-of-8 clean to **8/8 @ 100%**. The prompt defect was the
 dominant signal in the measurement, so the model ranking derived from it is unvalidated.
 
@@ -19,8 +19,9 @@ re-applying it.
 
 ## Prerequisite
 
-The `strongMatches` evidence-rule fix is merged to `main`, and `npm run eval:match` on baseline
-`gemini-2.5-flash` reproduces 8/8 @ 100%.
+Satisfied: the `strongMatches` evidence-rule fix from `73f72a4` is merged to `main` through
+#131, and `npm run eval:match` on baseline `gemini-2.5-flash` reproduced **8/8 @ 100%**. That
+is the baseline result the re-sweep must reproduce before comparing a candidate.
 
 If it does not reproduce, stop. An unstable gate makes any model comparison meaningless, and the
 instability is the more important finding.
@@ -32,8 +33,10 @@ deletes `GEMINI_API_KEY` so a non-Google model id cannot silently fall back to G
 bogus name):
 
 - **3 runs per model.** Report mean plus per-fixture min/max. The harness currently runs each
-  fixture once and reports no spread, while the observed within-model swing
-  (3.5-flash-lite on `arabic-accountant-partial`: 100% → 78% → 78%) is larger than the
+  fixture once and reports no spread. Independently, the baseline's temp-0 boilerplate pair
+  measured a 4–7 point spread across three live runs (82/78, 83/78, 78/85), corroborating that
+  one run per fixture cannot distinguish model signal from run variance. The earlier observed
+  3.5-flash-lite swing (on `arabic-accountant-partial`: 100% → 78% → 78%) is larger than the
   between-model gaps under comparison.
 - **Record per-fixture latency** alongside score. Latency is the actual thesis of the switch and
   the eval does not measure it. Report median and p95.
@@ -90,9 +93,16 @@ instrument and taking the measurement in the same pass makes neither trustworthy
 ## Known eval limits this design works around
 
 `npm run eval:match` is a sound regression gate: deterministic scorer with no LLM judge, exit code
-counts hard failures and invariance-group band crossings (`scripts/match-eval.mjs:185`), missing
-caches hard-error rather than silently skipping. It is not a ranking instrument — hence the 3-run
-requirement and the pre-committed decision rule above.
+counts hard failures and tolerance-gated invariance failures. `scripts/match-eval.mjs:175-181`
+marks a result failed only after `getInvariantGroupFailures`; its failure list is still assembled
+at `scripts/match-eval.mjs:185`. That helper uses `BAND_CROSS_TOLERANCE = 8`: a group must cross
+the published product bands *and* have a spread of at least 9 points before it fails. The
+bi-analyst clean/noisy pair sits on the 80 boundary, so its measured 4–7 point spread is tolerated
+and this particular guard is close to inert for that pair. If boilerplate sensitivity regresses,
+move the pair away from the boundary and restore a strict band-cross check rather than treating the
+tolerance as proof that boilerplate has no score effect. Missing caches still hard-error rather than
+silently skipping. It is not a ranking instrument — hence the 3-run requirement and the
+pre-committed decision rule above.
 
 One operational note: `eval/match-fixtures/*.actual.json` caches are model-dependent and committed.
 After any model change they hold the previous model's output, so a keyless run scores stale data

--- a/netlify/lib/model-registry.js
+++ b/netlify/lib/model-registry.js
@@ -29,6 +29,7 @@ const SUPPORTED_BENCHMARK_MODELS = [
   'google/gemini-2.5-flash-lite',
   'google/gemini-2.5-flash',
   'google/gemini-3.1-flash-lite',
+  'google/gemini-3.5-flash-lite',
 ];
 
 // ---------------------------------------------------------------------------
@@ -118,11 +119,13 @@ const FEATURE_CONFIGS = {
 // ---------------------------------------------------------------------------
 // Approximate pricing (USD per 1M tokens) — NOT actual billed cost.
 // Update these when provider pricing changes.
+// Last verified against the live OpenRouter catalog on 2026-07-26.
 // ---------------------------------------------------------------------------
 const APPROXIMATE_PRICING = {
-  'google/gemini-2.5-flash-lite': { prompt: 0.30, completion: 0.60 },
-  'google/gemini-2.5-flash':      { prompt: 0.50, completion: 2.00 },
-  'google/gemini-3.1-flash-lite': { prompt: 0.15, completion: 0.60 },
+  'google/gemini-2.5-flash-lite': { prompt: 0.10, completion: 0.40 },
+  'google/gemini-2.5-flash':      { prompt: 0.30, completion: 2.50 },
+  'google/gemini-3.1-flash-lite': { prompt: 0.25, completion: 1.50 },
+  'google/gemini-3.5-flash-lite': { prompt: 0.30, completion: 2.50 },
 };
 
 /**


### PR DESCRIPTION
## What

Two independent things, split into two commits:

1. **`fix(models)`** — corrects `APPROXIMATE_PRICING` in `netlify/lib/model-registry.js`. All three entries were wrong against the live OpenRouter catalog; completion price on the flash tier was understated 25%, so every `estimateCostUsd()` figure under-reported actual spend. Also adds `gemini-3.5-flash-lite` to `SUPPORTED_BENCHMARK_MODELS` + the pricing table, since it was evaluated this session and `benchmark:ai` would otherwise reject the slug.
2. **`docs`** — a spec for re-measuring the `ai_match` model choice.

**No production model defaults change in this PR.**

## Why the spec exists

A per-feature model sweep this session (parse / match / optimize gold sets, live OpenRouter calls) concluded that `gemini-3.5-flash-lite` should replace `gemini-2.5-flash` for `ai_match_reality_check` — quality parity at identical price ($0.30/$2.50), 2.5–3x lower latency (median 4.5–5.6s vs 13.5s).

That pin was wired and then **reverted**, because the measurement turned out to be resting on a defect:

- The sweep ran against a defective `strongMatches` prompt that penalised *every* model tested — the same fixture failed identically on five independent models, which is the signature of a prompt bug, not a model bug.
- The fix in flight takes baseline `gemini-2.5-flash` from **92% mean / 3-of-8 clean → 8/8 @ 100%**.
- So the prompt defect was the dominant signal, and any ranking derived from it is unvalidated.

The spec records the prerequisite, the method (3 runs per model with reported spread, plus latency capture), a decision rule fixed *before* seeing data, and the pin mechanism to restore if the rule passes.

## Eval reliability findings (in the spec)

`npm run eval:match` is a sound **regression gate** — deterministic scorer, no LLM judge; exit code counts hard failures *and* invariance-group band crossings; missing caches hard-error. It is **not** a ranking instrument:

- One run per fixture, no variance output — observed within-model swing (100% → 78% → 78% on the Arabic fixture) exceeds the between-model gaps being compared.
- Ceiling effect once baseline is 8/8 @ 100% — a candidate can tie but not win.
- Arabic is 1 of 8 fixtures, and it is where candidates wobble.
- No latency assertion, despite latency being the usual reason to switch.
- `*.actual.json` caches are model-dependent and committed, so after a model change a keyless run scores stale output while appearing to validate prod.

## Blocked on

The `strongMatches` evidence-rule fix landing on `main`. Until then the re-sweep cannot start.

## Test plan

- `npx vitest run netlify/lib/__tests__/ai-contracts.test.js` → 31 pass / 0 fail
- `npm run type:check` → ok
- `eslint netlify/lib/model-registry.js` → clean
- Pricing values spot-checked against `https://openrouter.ai/api/v1/models` on 2026-07-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
